### PR TITLE
plugin: fix memory leak when freeing plugin chains

### DIFF
--- a/src/he/plugin_chain.c
+++ b/src/he/plugin_chain.c
@@ -25,7 +25,10 @@ he_plugin_chain_t *he_plugin_create_chain(void) {
 }
 
 void he_plugin_destroy_chain(he_plugin_chain_t *chain) {
-  he_internal_free(chain);
+  if (chain) {
+    he_plugin_destroy_chain(chain->next);
+    he_internal_free(chain);
+  }
 }
 
 he_return_code_t he_plugin_register_plugin(he_plugin_chain_t *chain, plugin_struct_t *plugin) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix a memory leak when releasing plugin chains

## How Has This Been Tested?
Contains autotests and compiled locally with `ceedling test project:macos`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`