### PR TITLE
conn: const correct setting auth buffers

### DIFF
--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -678,7 +678,7 @@ bool he_conn_is_password_set(const he_conn_t *conn) {
   return !he_internal_config_is_empty_string(conn->password);
 }
 
-he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, uint8_t *buffer,
+he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length) {
   if(conn == NULL || buffer == NULL) {
     return HE_ERR_NULL_POINTER;

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -142,7 +142,7 @@ bool he_conn_is_password_set(const he_conn_t *conn);
  * @return HE_SUCCESS the auth buffer has been set
  * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
  */
-he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, uint8_t *buffer,
+he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length);
 /**
  * @brief Check if the auth buffer has been set


### PR DESCRIPTION
We make a copy inside so the buffer passed should be const.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`