### PR TITLE
msg_handlers: check auth buffer length before passing to auth_buffer_cb

### DIFF
--- a/src/he/msg_handlers.c
+++ b/src/he/msg_handlers.c
@@ -199,10 +199,20 @@ he_return_code_t he_handle_msg_auth(he_conn_t *conn, uint8_t *packet, int length
     }
   } else {
     if(conn->auth_buf_cb) {
+      // Check the packet is big enough
+      if(length <= sizeof(he_msg_auth_buf_t)) {
+        return HE_ERR_PACKET_TOO_SMALL;
+      }
+
       he_msg_auth_buf_t *msg_buf = (he_msg_auth_buf_t *)packet;
-      uint16_t host_length = ntohs(msg_buf->buffer_length);
-      auth_state = conn->auth_buf_cb(conn, msg_buf->header.auth_type, msg_buf->buffer, host_length,
-                                     conn->data);
+
+      // Check the auth buffer length
+      uint16_t auth_buf_length = ntohs(msg_buf->buffer_length);
+      if(auth_buf_length > (length - sizeof(he_msg_auth_hdr_t))) {
+        return HE_ERR_PACKET_TOO_SMALL;
+      }
+      auth_state = conn->auth_buf_cb(conn, msg_buf->header.auth_type, msg_buf->buffer,
+                                     auth_buf_length, conn->data);
     } else {
       auth_res = HE_ERR_ACCESS_DENIED_NO_AUTH_BUF_HANDLER;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Check auth buffer length is valid before passing to the user provided `auth_buffer_cb` callback.

## Motivation and Context
Prevent potential out-of-bound read in the user provided code.

## How Has This Been Tested?
I've added a unit test for this fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`