### PR TITLE
Upgrade WolfSSL to 5.2.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -50,6 +50,7 @@
     bool:     UINT8
   :treat_as_array:
     WOLFSSL_API void
+    va_list void
   :strippables:
     - WOLFSSL_API
     - WOLFSSL_LOCAL

--- a/test/support/wolfssl_testable_types.h
+++ b/test/support/wolfssl_testable_types.h
@@ -83,4 +83,7 @@ struct WOLFSSL_EVP_MD_CTX {
   int id;
 };
 
+struct WOLFSSL_X509_EXTENSION {
+  int id;
+};
 #endif

--- a/unix.yml
+++ b/unix.yml
@@ -16,7 +16,7 @@
 
 :environment:
   - :he_wolfssl_source: https://github.com/wolfSSL/wolfssl
-  - :he_wolfssl_commit: d8dd69cf44825b8bf0364e1d8a1fea548b948e34
+  - :he_wolfssl_commit: v5.2.0-stable
 
 :tools_test_file_preprocessor:
   :arguments:

--- a/windows_32.yml
+++ b/windows_32.yml
@@ -46,7 +46,7 @@
       :fetch:
         :method: :git
         :source: https://github.com/wolfSSL/wolfssl.git
-        :hash: d8dd69cf44825b8bf0364e1d8a1fea548b948e34
+        :hash: v5.2.0-stable
       :build:
         - "cp ../../windows/wolfssl-user_settings-32.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-32.h IDE/WIN/user_settings.h"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -46,7 +46,7 @@
       :fetch:
         :method: :git
         :source: https://github.com/wolfSSL/wolfssl.git
-        :hash: d8dd69cf44825b8bf0364e1d8a1fea548b948e34
+        :hash: v5.2.0-stable
       :build:
         - "cp ../../windows/wolfssl-user_settings-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-64.h IDE/WIN/user_settings.h"


### PR DESCRIPTION
## Description
* Use version 5.2.0 of WolfSSL
* Add mock struct for new WolfSSL type (`WOLFSSL_X509_EXTENSION`)
* Add `va_list` to `treat as array` list for test generation

## Motivation and Context
Brings WolfSSL up to date.

## How Has This Been Tested?
Test suite as part of `earthly +all` completes successfully


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Upgrade dependency

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All active GitHub checks are passing  
- [X] The correct base branch is being used, if not `main`