### PR TITLE
Add new auth type (HE_AUTH_TYPE_CB) and deprecate he_conn_set_auth_buffer

### DIFF
--- a/include/he.h
+++ b/include/he.h
@@ -196,6 +196,8 @@ typedef enum he_return_code {
   HE_ERR_ACCESS_DENIED_NO_AUTH_USERPASS_HANDLER = -55,
   /// The client has received the goodbye message from server
   HE_ERR_SERVER_GOODBYE = -56,
+  /// Invalid authentication type
+  HE_ERR_INVALID_AUTH_TYPE = -57,
 } he_return_code_t;
 
 /**
@@ -609,7 +611,13 @@ typedef enum msg_ids {
   HE_MSGID_DEPRECATED_13 = 13
 } msg_ids_t;
 
-typedef enum he_auth_type { HE_AUTH_TYPE_USERPASS = 1 } he_auth_type_t;
+typedef enum he_auth_type {
+  /// Authenticate with username and password
+  HE_AUTH_TYPE_USERPASS = 1,
+
+  /// Authenticate with custom callback
+  HE_AUTH_TYPE_CB = 23,
+} he_auth_type_t;
 
 /** Begin Public Section **/
 

--- a/public/he.h
+++ b/public/he.h
@@ -168,6 +168,8 @@ typedef enum he_return_code {
   HE_ERR_ACCESS_DENIED_NO_AUTH_USERPASS_HANDLER = -55,
   /// The client has received the goodbye message from server
   HE_ERR_SERVER_GOODBYE = -56,
+  /// Invalid authentication type
+  HE_ERR_INVALID_AUTH_TYPE = -57,
 } he_return_code_t;
 
 /**
@@ -982,9 +984,24 @@ bool he_conn_is_password_set(const he_conn_t *conn);
  *
  * @return HE_SUCCESS the auth buffer has been set
  * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
+ *
+ * @deprecated This function is deprecated. It just calls he_conn_set_auth_buffer2 which sets the
+ * auth_type to HE_AUTH_TYPE_CB internally.
  */
+HE_DEPRECATED(he_conn_set_auth_buffer2)
 he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length);
+
+/**
+ * @brief Sets the opaque buffer Helium should use to authenticate with
+ * @param conn A pointer to a valid connection
+ * @param buffer A pointer to the authentication buffer to use
+ * @param length The length of the buffer
+ *
+ * @return HE_SUCCESS the auth buffer has been set
+ * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
+ */
+he_return_code_t he_conn_set_auth_buffer2(he_conn_t *conn, const uint8_t *buffer, uint16_t length);
 
 /**
  * @brief Check if the auth buffer has been set

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -813,6 +813,10 @@ bool he_conn_is_password_set(const he_conn_t *conn) {
 
 he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length) {
+  return he_conn_set_auth_buffer2(conn, buffer, length);
+}
+
+he_return_code_t he_conn_set_auth_buffer2(he_conn_t *conn, const uint8_t *buffer, uint16_t length) {
   if(conn == NULL || buffer == NULL) {
     return HE_ERR_NULL_POINTER;
   }
@@ -825,11 +829,7 @@ he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, con
     return HE_ERR_STRING_TOO_LONG;
   }
 
-  if(auth_type == HE_AUTH_TYPE_USERPASS) {
-    return HE_ERR_CONF_CONFLICTING_AUTH_METHODS;
-  }
-
-  conn->auth_type = auth_type;
+  conn->auth_type = HE_AUTH_TYPE_CB;
   memcpy(conn->auth_buffer, buffer, length);
   conn->auth_buffer_length = length;
 

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -478,8 +478,8 @@ static he_return_code_t he_internal_send_auth_userpass(he_conn_t *conn) {
   auth.header.auth_type = HE_AUTH_TYPE_USERPASS;
 
   // Get and set the cred lengths
-  auth.username_length = (uint8_t)strnlen(conn->username, sizeof(conn->username) -1);
-  auth.password_length = (uint8_t)strnlen(conn->password, sizeof(conn->password) -1);
+  auth.username_length = (uint8_t)strnlen(conn->username, sizeof(conn->username) - 1);
+  auth.password_length = (uint8_t)strnlen(conn->password, sizeof(conn->password) - 1);
 
   // Copy the creds into the message
   memcpy(&auth.username, conn->username, auth.username_length);
@@ -530,10 +530,13 @@ he_return_code_t he_internal_send_auth(he_conn_t *conn) {
   // Change state to authenticating
   he_internal_change_conn_state(conn, HE_STATE_AUTHENTICATING);
 
-  if(conn->auth_type == HE_AUTH_TYPE_USERPASS) {
-    return he_internal_send_auth_userpass(conn);
-  } else {
-    return he_internal_send_auth_buf(conn);
+  switch(conn->auth_type) {
+    case HE_AUTH_TYPE_USERPASS:
+      return he_internal_send_auth_userpass(conn);
+    case HE_AUTH_TYPE_CB:
+      return he_internal_send_auth_buf(conn);
+    default:
+      return HE_ERR_INVALID_AUTH_TYPE;
   }
 }
 

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -141,9 +141,25 @@ bool he_conn_is_password_set(const he_conn_t *conn);
  *
  * @return HE_SUCCESS the auth buffer has been set
  * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
+ *
+ * @deprecated This function is deprecated. It just calls he_conn_set_auth_buffer2 which sets the
+ * auth_type to HE_AUTH_TYPE_CB internally.
  */
+HE_DEPRECATED(he_conn_set_auth_buffer2)
 he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length);
+
+/**
+ * @brief Sets the opaque buffer Helium should use to authenticate with
+ * @param conn A pointer to a valid connection
+ * @param buffer A pointer to the authentication buffer to use
+ * @param length The length of the buffer
+ *
+ * @return HE_SUCCESS the auth buffer has been set
+ * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
+ */
+he_return_code_t he_conn_set_auth_buffer2(he_conn_t *conn, const uint8_t *buffer, uint16_t length);
+
 /**
  * @brief Check if the auth buffer has been set
  * @param conn A pointer to a valid connection

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -84,7 +84,7 @@ void test_valid_to_connect_no_password(void) {
 
 void test_valid_to_connect_auth_buffer(void) {
   he_conn_t *test = he_conn_create();
-  int res1 = he_conn_set_auth_buffer(test, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet,
+  int res1 = he_conn_set_auth_buffer(test, HE_AUTH_TYPE_CB, fake_ipv4_packet,
                                      sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 
@@ -97,7 +97,7 @@ void test_valid_to_connect_auth_buffer(void) {
 
 void test_valid_to_connect_auth_buffer_and_username_password(void) {
   he_conn_t *test = he_conn_create();
-  int res1 = he_conn_set_auth_buffer(test, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet,
+  int res1 = he_conn_set_auth_buffer(test, HE_AUTH_TYPE_CB, fake_ipv4_packet,
                                      sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 
@@ -223,7 +223,7 @@ void test_is_password_set(void) {
 // Handling Auth buffer
 
 void test_set_auth_buffer(void) {
-  int res1 = he_conn_set_auth_buffer(&conn, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet,
+  int res1 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet,
                                      sizeof(fake_ipv4_packet));
 
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
@@ -246,22 +246,22 @@ void test_set_auth_buffer_too_long(void) {
 }
 
 void test_set_auth_buffer_nulls(void) {
-  int res1 = he_conn_set_auth_buffer(NULL, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet,
+  int res1 = he_conn_set_auth_buffer(NULL, HE_AUTH_TYPE_CB, fake_ipv4_packet,
                                      sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res1);
   int res2 =
-      he_conn_set_auth_buffer(&conn, HOST_PROVIDED_AUTH_TYPE, NULL, sizeof(fake_ipv4_packet));
+      he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, NULL, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res2);
 }
 
 void test_set_auth_buffer_empty(void) {
-  int res1 = he_conn_set_auth_buffer(&conn, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet, 0);
+  int res1 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet, 0);
   TEST_ASSERT_EQUAL(HE_ERR_EMPTY_STRING, res1);
 }
 
 void test_is_auth_buffer_set(void) {
   bool res1 = he_conn_is_auth_buffer_set(&conn);
-  int res2 = he_conn_set_auth_buffer(&conn, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet,
+  int res2 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet,
                                      sizeof(fake_ipv4_packet));
   bool res3 = he_conn_is_auth_buffer_set(&conn);
 
@@ -1068,7 +1068,7 @@ void test_he_internal_send_auth_bad_state(void) {
 
 void test_he_internal_send_auth_buf(void) {
   conn.state = HE_STATE_AUTHENTICATING;
-  he_conn_set_auth_buffer(&conn, HOST_PROVIDED_AUTH_TYPE, fake_ipv4_packet,
+  he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet,
                           sizeof(fake_ipv4_packet));
 
   wolfSSL_write_ExpectAnyArgsAndReturn(150);

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -84,8 +84,7 @@ void test_valid_to_connect_no_password(void) {
 
 void test_valid_to_connect_auth_buffer(void) {
   he_conn_t *test = he_conn_create();
-  int res1 = he_conn_set_auth_buffer(test, HE_AUTH_TYPE_CB, fake_ipv4_packet,
-                                     sizeof(fake_ipv4_packet));
+  int res1 = he_conn_set_auth_buffer2(test, fake_ipv4_packet, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 
   int res2 = he_conn_set_outside_mtu(test, HE_MAX_WIRE_MTU);
@@ -97,8 +96,7 @@ void test_valid_to_connect_auth_buffer(void) {
 
 void test_valid_to_connect_auth_buffer_and_username_password(void) {
   he_conn_t *test = he_conn_create();
-  int res1 = he_conn_set_auth_buffer(test, HE_AUTH_TYPE_CB, fake_ipv4_packet,
-                                     sizeof(fake_ipv4_packet));
+  int res1 = he_conn_set_auth_buffer2(test, fake_ipv4_packet, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 
   int res2 = he_conn_set_username(test, "myuser");
@@ -223,46 +221,34 @@ void test_is_password_set(void) {
 // Handling Auth buffer
 
 void test_set_auth_buffer(void) {
-  int res1 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet,
-                                     sizeof(fake_ipv4_packet));
+  int res1 = he_conn_set_auth_buffer2(&conn, fake_ipv4_packet, sizeof(fake_ipv4_packet));
 
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
-
+  TEST_ASSERT_EQUAL(HE_AUTH_TYPE_CB, conn.auth_type);
   TEST_ASSERT_EQUAL(sizeof(fake_ipv4_packet), conn.auth_buffer_length);
-
   TEST_ASSERT_EQUAL_UINT8_ARRAY(fake_ipv4_packet, conn.auth_buffer, conn.auth_buffer_length);
 }
 
-void test_set_auth_buffer_bad_type(void) {
-  int res1 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_USERPASS, fake_ipv4_packet,
-                                     sizeof(fake_ipv4_packet));
-
-  TEST_ASSERT_EQUAL(HE_ERR_CONF_CONFLICTING_AUTH_METHODS, res1);
-}
-
 void test_set_auth_buffer_too_long(void) {
-  int res1 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_USERPASS, fake_ipv4_packet, HE_MAX_MTU);
+  int res1 = he_conn_set_auth_buffer2(&conn, fake_ipv4_packet, HE_MAX_MTU);
   TEST_ASSERT_EQUAL(HE_ERR_STRING_TOO_LONG, res1);
 }
 
 void test_set_auth_buffer_nulls(void) {
-  int res1 = he_conn_set_auth_buffer(NULL, HE_AUTH_TYPE_CB, fake_ipv4_packet,
-                                     sizeof(fake_ipv4_packet));
+  int res1 = he_conn_set_auth_buffer2(NULL, fake_ipv4_packet, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res1);
-  int res2 =
-      he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, NULL, sizeof(fake_ipv4_packet));
+  int res2 = he_conn_set_auth_buffer2(&conn, NULL, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res2);
 }
 
 void test_set_auth_buffer_empty(void) {
-  int res1 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet, 0);
+  int res1 = he_conn_set_auth_buffer2(&conn, fake_ipv4_packet, 0);
   TEST_ASSERT_EQUAL(HE_ERR_EMPTY_STRING, res1);
 }
 
 void test_is_auth_buffer_set(void) {
   bool res1 = he_conn_is_auth_buffer_set(&conn);
-  int res2 = he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet,
-                                     sizeof(fake_ipv4_packet));
+  int res2 = he_conn_set_auth_buffer2(&conn, fake_ipv4_packet, sizeof(fake_ipv4_packet));
   bool res3 = he_conn_is_auth_buffer_set(&conn);
 
   TEST_ASSERT_EQUAL(false, res1);
@@ -1068,8 +1054,7 @@ void test_he_internal_send_auth_bad_state(void) {
 
 void test_he_internal_send_auth_buf(void) {
   conn.state = HE_STATE_AUTHENTICATING;
-  he_conn_set_auth_buffer(&conn, HE_AUTH_TYPE_CB, fake_ipv4_packet,
-                          sizeof(fake_ipv4_packet));
+  he_conn_set_auth_buffer2(&conn, fake_ipv4_packet, sizeof(fake_ipv4_packet));
 
   wolfSSL_write_ExpectAnyArgsAndReturn(150);
 
@@ -1188,7 +1173,6 @@ void test_he_conn_set_context_null_context(void) {
   he_return_code_t res = he_conn_set_context(&conn, NULL);
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
 }
-
 
 void test_he_conn_get_context_null_conn(void) {
   void *res = he_conn_get_context(NULL);

--- a/test/support/test_defs.h
+++ b/test/support/test_defs.h
@@ -2,7 +2,6 @@
 #define HE_TEST_DEFS
 
 #define FIXTURE_FATAL_ERROR -1
-#define HOST_PROVIDED_AUTH_TYPE 23
 
 char *bad_string_too_long = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Added a new error code: `HE_ERR_INVALID_AUTH_TYPE`. Client-side code may see this error when the `conn->auth_type` is set to unsupported value.
* Deprecate `he_conn_set_auth_buffer`. Client-side code should use `he_conn_set_auth_buffer2` instead. And both function will set the `auth_type` to `HE_AUTH_TYPE_CB`.
* Server-side code will response "Access Denied" if the auth message contains unsupported `auth_type`.

## Motivation and Context
Previously, a Lightway client can set any value to the `auth_type` field in the authentication message sent to the server, then the server side code just consider it's using "auth_buffer" without actually checking the value of auth_type. By using a specific code for the "auth buffer based" authentication, we can add support to more `auth_type` in the future.

## How Has This Been Tested?
All changes have been verified with earthly +test to ensure no breaking changes to the API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`