### PR TITLE
Improve error handling when calling wolfSSL_read and wolfSSL_write

### DIFF
--- a/test/he/test_flow.c
+++ b/test/he/test_flow.c
@@ -472,6 +472,7 @@ void test_handle_process_packet_connection_closed(void) {
                                sizeof(conn->read_packet.packet), 1200);
   wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet,
                                sizeof(conn->read_packet.packet), 0);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, 0, SSL_ERROR_SSL);
 
   int res = he_internal_flow_outside_packet_received(conn, packet, packet_max_length);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Improved error handling when calling `wolfSSL_read` and `wolfSSL_write`.

## Motivation and Context
According to wolfSSL documentation, we should always call `wolfSSL_get_error()` when [`wolfSSL_write`](https://www.wolfssl.com/doxygen/group__IO.html#gad6cbb3cb90e4d606e9507e4ec06197df) / [`wolfSSL_read`](https://www.wolfssl.com/doxygen/group__IO.html#ga80c3ccd3c0441c77307df3afe88a5c35) returns <= 0. And [`wolfSSL_get_error`](https://www.wolfssl.com/doxygen/group__Debug.html#gaafd5671d443fa684913ba5955a4eb591) may return `SSL_ERROR_NONE` in some cases:

> SSL_ERROR_NONE will be returned if ret > 0. For ret <= 0, there are some cases when this value can also be returned when a previous API appeared to return an error code but no error actually occurred. An example is calling [wolfSSL_read()](https://www.wolfssl.com/doxygen/group__IO.html#ga80c3ccd3c0441c77307df3afe88a5c35) with a zero sz parameter. A 0 return from [wolfSSL_read()](https://www.wolfssl.com/doxygen/group__IO.html#ga80c3ccd3c0441c77307df3afe88a5c35) usually indicates an error but in this case no error occurred.

## How Has This Been Tested?
Tested via existing test suite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`