### PR TITLE
conn: send goodbye messages on more states

### DIFF
--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -336,24 +336,6 @@ he_return_code_t he_conn_disconnect(he_conn_t *conn) {
     return HE_ERR_INVALID_CONN_STATE;
   }
 
-  // Handle the actual shut down
-  he_internal_disconnect_and_shutdown(conn);
-
-  // This will always be successful
-  return HE_SUCCESS;
-}
-
-void he_internal_disconnect_and_shutdown(he_conn_t *conn) {
-  // This will only be called internally, assume that any "pre flight" checks have been completed
-
-  // Return if conn is null
-  if(!conn) {
-    return;
-  }
-
-  // Get the conn's current state
-  he_conn_state_t state = conn->state;
-
   // Update state - we're disconnecting
   he_internal_change_conn_state(conn, HE_STATE_DISCONNECTING);
 
@@ -371,6 +353,9 @@ void he_internal_disconnect_and_shutdown(he_conn_t *conn) {
 
   // Change to disconnected state
   he_internal_change_conn_state(conn, HE_STATE_DISCONNECTED);
+
+  // This will always be successful
+  return HE_SUCCESS;
 }
 
 void he_internal_change_conn_state(he_conn_t *conn, he_conn_state_t state) {

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -331,7 +331,8 @@ he_return_code_t he_conn_disconnect(he_conn_t *conn) {
   }
 
   // Return error if in the wrong state
-  if(conn->state != HE_STATE_ONLINE) {
+  if(conn->state == HE_STATE_DISCONNECTING || conn->state == HE_STATE_NONE ||
+      conn->state == HE_STATE_CONNECTING || conn->state == HE_STATE_DISCONNECTED) {
     return HE_ERR_INVALID_CONN_STATE;
   }
 
@@ -356,10 +357,7 @@ void he_internal_disconnect_and_shutdown(he_conn_t *conn) {
   // Update state - we're disconnecting
   he_internal_change_conn_state(conn, HE_STATE_DISCONNECTING);
 
-  // Send goodbye if we were online
-  if(state == HE_STATE_ONLINE) {
-    he_internal_send_goodbye(conn);
-  }
+  he_internal_send_goodbye(conn);
 
   // Talk to the other end to shut down the D/TLS session
   // Note: We aren't checking the return code as we're going to destroy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Send goodbye messages on more states

## Motivation and Context
Prevents servers from thinking that the connection is active when in fact the user has already disconnected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`