### PR TITLE
build: use bullseye image for builds

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,5 @@
-FROM debian:buster-slim
+VERSION 0.6
+FROM debian:bullseye-slim
 WORKDIR /libhelium
 
 debian-deps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a version number to prevent an earthly warning and uses the latest debian for builds

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested with `earthly +all`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`