### PR TITLE
Fix windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,25 +66,29 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Ceedling
         run: gem install ceedling --no-user-install
+      - name: Check Ceedling version
+        run: ceedling version
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
           arch: x64
       - name: Build dependencies
         run: ceedling project:windows_64 clobber dependencies:make
-      - name: Run build release
-        run: ceedling project:windows_64 release
+      - name: Run build and test
+        run: ceedling project:windows_64
   windows-32bit:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
         run: gem install ceedling --no-user-install
+      - name: Check Ceedling version
+        run: ceedling version
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
           arch: x86
       - name: Build dependencies
         run: ceedling project:windows_32 clobber dependencies:make
-      - name: Run build release
-        run: ceedling project:windows_32 release
+      - name: Run build and test
+        run: ceedling project:windows_32

--- a/public/he.h
+++ b/public/he.h
@@ -988,7 +988,6 @@ bool he_conn_is_password_set(const he_conn_t *conn);
  * @deprecated This function is deprecated. It just calls he_conn_set_auth_buffer2 which sets the
  * auth_type to HE_AUTH_TYPE_CB internally.
  */
-HE_DEPRECATED(he_conn_set_auth_buffer2)
 he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length);
 

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -145,7 +145,6 @@ bool he_conn_is_password_set(const he_conn_t *conn);
  * @deprecated This function is deprecated. It just calls he_conn_set_auth_buffer2 which sets the
  * auth_type to HE_AUTH_TYPE_CB internally.
  */
-HE_DEPRECATED(he_conn_set_auth_buffer2)
 he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
                                          uint16_t length);
 

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -458,9 +458,9 @@ void test_send_keepalive_connected(void) {
 }
 
 void test_disconnect_in_valid_states_sends_goodbye_and_shuts_down(void) {
-  he_conn_state_t states[] = { HE_STATE_AUTHENTICATING, HE_STATE_CONFIGURING,
-                               HE_STATE_LINK_UP, HE_STATE_ONLINE };
-  for (int i = 0; i < sizeof(states) / sizeof(states[0]); ++i) {
+  he_conn_state_t states[] = {HE_STATE_AUTHENTICATING, HE_STATE_CONFIGURING, HE_STATE_LINK_UP,
+                              HE_STATE_ONLINE};
+  for(int i = 0; i < sizeof(states) / sizeof(states[0]); ++i) {
     conn.state = states[i];
     conn.outside_write_cb = write_cb;
     conn.inside_write_cb = write_cb;
@@ -478,9 +478,9 @@ void test_disconnect_in_valid_states_sends_goodbye_and_shuts_down(void) {
 }
 
 void test_disconnect_reject_if_in_invalid_states(void) {
-  he_conn_state_t states[] = { HE_STATE_NONE, HE_STATE_DISCONNECTED,
-                               HE_STATE_DISCONNECTING, HE_STATE_CONNECTING };
-  for (int i = 0; i < sizeof(states) / sizeof(states[0]); ++i) {
+  he_conn_state_t states[] = {HE_STATE_NONE, HE_STATE_DISCONNECTED, HE_STATE_DISCONNECTING,
+                              HE_STATE_CONNECTING};
+  for(int i = 0; i < sizeof(states) / sizeof(states[0]); ++i) {
     conn.state = states[i];
     he_return_code_t res = he_conn_disconnect(&conn);
     TEST_ASSERT_EQUAL(HE_ERR_INVALID_CONN_STATE, res);
@@ -736,9 +736,9 @@ void test_he_conn_rotate_session_id_rng_failure(void) {
   uint64_t test_session = 0;
   conn.is_server = true;
 
-  wc_RNG_GenerateBlock_ExpectAndReturn(&conn.wolf_rng, (byte *)&test_session, sizeof(uint64_t),
+  wc_RNG_GenerateBlock_ExpectAndReturn(&conn.wolf_rng, (byte *)NULL, sizeof(uint64_t),
                                        FIXTURE_FATAL_ERROR);
-
+  wc_RNG_GenerateBlock_IgnoreArg_bytes();
   int res = he_conn_rotate_session_id(&conn, &test_session);
 
   TEST_ASSERT_EQUAL(HE_ERR_RNG_FAILURE, res);
@@ -1265,7 +1265,6 @@ void test_he_internal_conn_configure_null(void) {
 }
 
 void test_he_internal_conn_configure_no_version(void) {
-
   ssl_ctx.disable_roaming_connections = true;
   ssl_ctx.padding_type = HE_PADDING_FULL;
   ssl_ctx.use_aggressive_mode = true;
@@ -1294,8 +1293,10 @@ void test_he_internal_conn_configure_no_version(void) {
   TEST_ASSERT_EQUAL(conn.use_aggressive_mode, ssl_ctx.use_aggressive_mode);
   TEST_ASSERT_EQUAL(conn.connection_type, ssl_ctx.connection_type);
 
-  TEST_ASSERT_EQUAL(conn.protocol_version.major_version, ssl_ctx.maximum_supported_version.major_version);
-  TEST_ASSERT_EQUAL(conn.protocol_version.minor_version, ssl_ctx.maximum_supported_version.minor_version);
+  TEST_ASSERT_EQUAL(conn.protocol_version.major_version,
+                    ssl_ctx.maximum_supported_version.major_version);
+  TEST_ASSERT_EQUAL(conn.protocol_version.minor_version,
+                    ssl_ctx.maximum_supported_version.minor_version);
 
   TEST_ASSERT_EQUAL(conn.auth_buf_cb, ssl_ctx.auth_buf_cb);
   TEST_ASSERT_EQUAL(conn.auth_cb, ssl_ctx.auth_cb);

--- a/test/he/test_plugin_chain.c
+++ b/test/he/test_plugin_chain.c
@@ -47,10 +47,8 @@ he_plugin_return_code_t call_counting_plugin_egress(uint8_t *packet, size_t *len
   return HE_PLUGIN_SUCCESS;
 }
 
-plugin_struct_t call_counting_plugin = {
-  do_ingress : call_counting_plugin_ingress,
-  do_egress : call_counting_plugin_egress
-};
+plugin_struct_t call_counting_plugin = {.do_ingress = call_counting_plugin_ingress,
+                                        .do_egress = call_counting_plugin_egress};
 
 he_plugin_return_code_t drop_if_zero(uint8_t *packet, size_t *length, size_t capacity, void *data) {
   for(int i = 0; i < *length; i++) {
@@ -62,13 +60,19 @@ he_plugin_return_code_t drop_if_zero(uint8_t *packet, size_t *length, size_t cap
   return HE_PLUGIN_DROP;
 }
 
-plugin_struct_t zero_dropping_plugin = {do_ingress : drop_if_zero, do_egress : drop_if_zero};
+plugin_struct_t zero_dropping_plugin = {
+    .do_ingress = drop_if_zero,
+    .do_egress = drop_if_zero,
+};
 
 he_plugin_return_code_t always_fail(uint8_t *packet, size_t *length, size_t capacity, void *data) {
   return HE_PLUGIN_FAIL;
 }
 
-plugin_struct_t failing_plugin = {do_ingress : always_fail, do_egress : always_fail};
+plugin_struct_t failing_plugin = {
+    .do_ingress = always_fail,
+    .do_egress = always_fail,
+};
 
 he_plugin_return_code_t zero_packet(uint8_t *packet, size_t *length, size_t capacity, void *data) {
   for(int i = 0; i < *length; i++) {
@@ -78,10 +82,17 @@ he_plugin_return_code_t zero_packet(uint8_t *packet, size_t *length, size_t capa
   return HE_PLUGIN_SUCCESS;
 }
 
-plugin_struct_t wipeout_plugin = {do_ingress : zero_packet, do_egress : zero_packet};
+plugin_struct_t wipeout_plugin = {
+    .do_ingress = zero_packet,
+    .do_egress = zero_packet,
+};
 
-plugin_struct_t only_ingress_plugin = {do_ingress : call_counting_plugin_ingress};
-plugin_struct_t only_egress_plugin = {do_egress : call_counting_plugin_egress};
+plugin_struct_t only_ingress_plugin = {
+    .do_ingress = call_counting_plugin_ingress,
+};
+plugin_struct_t only_egress_plugin = {
+    .do_egress = call_counting_plugin_egress,
+};
 
 void setUp(void) {
   packet = calloc(1, packet_max_length);
@@ -246,7 +257,7 @@ void test_plugin_destroy_chain_single(void) {
 void test_plugin_destroy_chain_multiple_plugins(void) {
   he_plugin_chain_t sibling = {0};
   he_plugin_chain_t chain = {
-    .next = &sibling,
+      .next = &sibling,
   };
   he_internal_free_Expect(&chain);
   he_internal_free_Expect(&sibling);

--- a/test/he/test_plugin_chain.c
+++ b/test/he/test_plugin_chain.c
@@ -259,7 +259,7 @@ void test_plugin_destroy_chain_multiple_plugins(void) {
   he_plugin_chain_t chain = {
       .next = &sibling,
   };
-  he_internal_free_Expect(&chain);
   he_internal_free_Expect(&sibling);
+  he_internal_free_Expect(&chain);
   he_plugin_destroy_chain(&chain);
 }

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -96,7 +96,7 @@
      :arguments:
         - /MACHINE:X64
         - "${1}"
-        - /FORCE:MULTIPLE # /IGNORE:LNK4006 # mocks deliberatey duplicate symbols
+        - /FORCE:MULTIPLE # /IGNORE:LNK4006 # mocks deliberately duplicate symbols
         - /LTCG
         - "${5}"
         - "${4}"


### PR DESCRIPTION
## Description
Fix unit tests on Windows.

## Motivation and Context
The tests were broken on windows because Ceedling / CMock couldn't process the `HE_DEPRECATE` C macro properly. We have to remove it from `he.h` and `conn.h` to workaround it. Unfortunately that means we cannot warn users of the deprecated `he_conn_set_auth_buffer` function to switch to `he_conn_set_auth_buffer2` anymore.

This PR also fixed another issue in test code which used non-standard way to initialize C struct which also breaks the windows test build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`