### PR TITLE
Build: Update build flags

### DIFF
--- a/linux.yml
+++ b/linux.yml
@@ -18,7 +18,7 @@
       - CFLAGS=-g -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       :build:
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation"
+        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples"
         - "make"
         - "make install"
       :artifacts:

--- a/linux.yml
+++ b/linux.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-      - CFLAGS=-g -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
+      - CFLAGS=-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       :build:
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples"
@@ -28,10 +28,4 @@
         :static_libraries:
           - lib/libwolfssl.a
 
-:flags:
-  :release:
-    :compile:
-      :*:
-        - -O2
-        - -Wall
 ...

--- a/linux_386.yml
+++ b/linux_386.yml
@@ -19,7 +19,7 @@
       - LDFLAGS= -m32
       :build:
         - "autoreconf -i"
-        - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation"
+        - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples"
         - "make"
         - "make install"
       :artifacts:

--- a/linux_386.yml
+++ b/linux_386.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-      - CFLAGS= -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -m32
+      - CFLAGS=-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -m32
       - LDFLAGS= -m32
       :build:
         - "autoreconf -i"
@@ -36,7 +36,6 @@
   :release:
     :compile:
       :*:
-        - -O2
         - -m32
 
 ...

--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-      - CFLAGS= -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
+      - CFLAGS=-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       :build:
         - "autoreconf -i"
         - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples"
@@ -27,11 +27,5 @@
           - include/wolfssl # needed e.g. for mock_ssl.h to find wolfssl/ssl.h
         :static_libraries:
           - lib/libwolfssl.a
-
-:flags:
-  :release:
-    :compile:
-      :*:
-        - -O2
 
 ...

--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -18,7 +18,7 @@
       - CFLAGS= -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       :build:
         - "autoreconf -i"
-        - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation"
+        - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples"
         - "make"
         - "make install"
       :artifacts:

--- a/macos.yml
+++ b/macos.yml
@@ -17,7 +17,7 @@
       :environment:
       - CFLAGS=-g -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       - CC=clang
-      - MACOSX_DEPLOYMENT_TARGET=10.0
+      - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples"
@@ -41,6 +41,6 @@
         - -g
 
 :environment:
-  - MACOSX_DEPLOYMENT_TARGET: 10.0
+  - MACOSX_DEPLOYMENT_TARGET: 10.10
 
 ...

--- a/macos.yml
+++ b/macos.yml
@@ -20,7 +20,7 @@
       - MACOSX_DEPLOYMENT_TARGET=10.0
       :build:
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation"
+        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples"
         - "make"
         - "make install"
       :artifacts:

--- a/macos.yml
+++ b/macos.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-      - CFLAGS=-g -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
+      - CFLAGS=-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       - CC=clang
       - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
@@ -29,16 +29,6 @@
           - include/wolfssl # needed e.g. for mock_ssl.h to find wolfssl/ssl.h
         :static_libraries:
           - lib/libwolfssl.a
-
-:flags:
-  :release:
-    :compile:
-      :*:
-        - -O2
-  :test:
-    :compile:
-      :*:
-        - -g
 
 :environment:
   - MACOSX_DEPLOYMENT_TARGET: 10.10

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -17,7 +17,7 @@
       :environment:
       - CFLAGS=-O2 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -target arm64-apple-darwin
       - CC=clang
-      - MACOSX_DEPLOYMENT_TARGET=10.0
+      - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
         - "autoreconf -i"
         - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm --disable-examples"
@@ -38,6 +38,6 @@
         - -target arm64-apple-macos10.16
 
 :environment:
-  - MACOSX_DEPLOYMENT_TARGET: 10.0
+  - MACOSX_DEPLOYMENT_TARGET: 10.10
 
 ...

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -20,7 +20,7 @@
       - MACOSX_DEPLOYMENT_TARGET=10.0
       :build:
         - "autoreconf -i"
-        - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm"
+        - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm --disable-examples"
         - "make"
         - "make install"
       :artifacts:

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-      - CFLAGS=-O2 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -target arm64-apple-darwin
+      - CFLAGS=-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -target arm64-apple-darwin
       - CC=clang
       - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
@@ -34,7 +34,6 @@
   :release:
     :compile:
       :*:
-        - -O2
         - -target arm64-apple-macos10.16
 
 :environment:

--- a/unix.yml
+++ b/unix.yml
@@ -42,7 +42,7 @@
       :*:
         - -g
         - -fPIC
-        - -O2
+        - -O3
   :test:
     :compile:
       :*:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use O3 Optimizations, increase MAC deployment target and disable wolfssl examples

## Motivation and Context
- We build some repositories with O3 and some with O2, On gcc O2 does not autovectorize but O3 does.
- Mac deployment target will prevent a warning
- Disable wolfssl examples as we do not use them

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`