### PR TITLE
Reduce multiplier for renegotiation timers

### DIFF
--- a/src/he/client.h
+++ b/src/he/client.h
@@ -28,10 +28,6 @@
 
 #include <he.h>
 
-// Scale 1 second to wolf to 100ms
-#define HE_WOLF_TIMEOUT_MULTIPLIER 100
-#define HE_WOLF_RENEGOTIATION_TIMEOUT_MULTIPLIER 1000
-
 /**
  * @brief Creates a Helium client
  * @return he_client_t* Returns a pointer to a valid Helium context

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -28,9 +28,25 @@
 
 #include <he.h>
 
-// Scale 1 second to wolf to 100ms
+/**
+ * D/TLS is a UDP based protocol and requires the application
+ * (rather than the OS as with TCP) to keep track of the need to do
+ * retransmits on packet loss.
+ * 
+ * Currently Wolf has timeouts based in seconds. However this is not
+ * sufficient for our goal of sub-second connection times.
+ * 
+ * As WolfSSL lacks millisecond timers we use its internal timers but
+ * change its definition to be in 100 millisecond intervals instead of
+ * seconds. So a wolf timeout of 1 second means 100 milliseconds.
+ * 
+ * By default wolf's DTLS max timeout is 64 seconds which translates to
+ * 6.4 seconds. Since it scales from 1 to 64 by a factor
+ * of 2 each timeout. The total timeout is 12.7 seconds with this scaling
+ * which for our purposes is plenty.
+ */
 #define HE_WOLF_TIMEOUT_MULTIPLIER 100
-#define HE_WOLF_RENEGOTIATION_TIMEOUT_MULTIPLIER 1000
+#define HE_WOLF_RENEGOTIATION_TIMEOUT_MULTIPLIER 100
 
 /**
  * @brief Creates a Helium connection struct

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -361,11 +361,32 @@ void test_get_nudge_time_while_connected_renegotiating(void) {
   TEST_ASSERT_EQUAL(5, res1);
 }
 
+void test_he_internal_update_timeout_online(void) {
+  TEST_ASSERT_EQUAL(0, call_counter);
+  conn.state = HE_STATE_ONLINE;
+
+  he_internal_update_timeout(&conn);
+  TEST_ASSERT_EQUAL(0, call_counter);
+}
+
 void test_he_internal_update_timeout(void) {
   TEST_ASSERT_EQUAL(0, call_counter);
 
   wolfSSL_dtls_get_current_timeout_ExpectAndReturn(conn.wolf_ssl, 10);
   he_internal_update_timeout(&conn);
+  TEST_ASSERT_EQUAL(conn.wolf_timeout, 10 * HE_WOLF_TIMEOUT_MULTIPLIER);
+
+  TEST_ASSERT_EQUAL(0, call_counter);
+}
+
+void test_he_internal_update_timeout_renegotiation(void) {
+  TEST_ASSERT_EQUAL(0, call_counter);
+  conn.renegotiation_in_progress = true;
+
+  wolfSSL_dtls_get_current_timeout_ExpectAndReturn(conn.wolf_ssl, 10);
+  he_internal_update_timeout(&conn);
+  TEST_ASSERT_EQUAL(conn.wolf_timeout, 10 * HE_WOLF_RENEGOTIATION_TIMEOUT_MULTIPLIER);
+
   TEST_ASSERT_EQUAL(0, call_counter);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reduce the renegotiation multiplier to 100 to match the initial connect multiplier

## Motivation and Context
We want to reduce the amount of time it takes before the renegotiation timer gives up. Prior to
this change it takes 127 seconds before it gives up this reduces it to a more reasonable 12.7 seconds.

## How Has This Been Tested?
- No manual testing performed CI, is enough here

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`