### PR TITLE
macos: Fix deployment target

### DIFF
--- a/macos.yml
+++ b/macos.yml
@@ -17,7 +17,6 @@
       :environment:
       - CFLAGS=-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
       - CC=clang
-      - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples"
@@ -31,6 +30,6 @@
           - lib/libwolfssl.a
 
 :environment:
-  - MACOSX_DEPLOYMENT_TARGET: 10.10
+  - MACOSX_DEPLOYMENT_TARGET: "10.10"
 
 ...


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix deployment target to 10.10, previously it was interpreted as 10.1

## Motivation and Context
The number gets interpreted as a double instead of a string.
So adding quotes fixes the deployment target.

## How Has This Been Tested?
Tested locally with ceedling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`