### PR TITLE
conn: treat HE_ERR_INCORRECT_PROTOCOL_VERSION as fatal error

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -881,7 +881,7 @@ he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx);
  * @note This function allocates memory
  *
  * This function must be called to create the initial Helium connection
- * for use with other functions
+ * for use with other functions.
  */
 he_conn_t *he_conn_create(void);
 
@@ -903,7 +903,8 @@ void he_conn_destroy(he_conn_t *conn);
  * @return HE_ERR_CONF_USERNAME_NOT_SET The username has not been set
  * @return HE_ERR_CONF_PASSWORD_NOT_SET The password has not been set
  * @return HE_ERR_CONF_MTU_NOT_SET The external MTU has not been set
- * @return HE_ERR_INCORRECT_PROTOCOL_VERSION The protocol version has been set
+ * @return HE_ERR_INCORRECT_PROTOCOL_VERSION The protocol version has been set but it's not equal to
+ * the maximum supported version defined in the ssl_ctx
  * @return HE_SUCCESS The basic configuration options have been set
  *
  * @note These return codes are similar to `he_conn_client_connect` because that function will call
@@ -1028,7 +1029,7 @@ int he_conn_set_outside_mtu(he_conn_t *conn, int mtu);
 
 /**
  * @brief Get the MTU value for the outside transport mechanism.
- * *@param conn A pointer to a valid connection.
+ * @param conn A pointer to a valid connection.
  * @ return int The MTU value in bytes.
  */
 int he_conn_get_outside_mtu(he_conn_t *conn);
@@ -1133,10 +1134,10 @@ he_return_code_t he_conn_disconnect(he_conn_t *conn);
  * @param conn A pointer to a valid connection
  * @return HE_SUCCESS Keep alive was sent
  *
- * This is used to send a heartbeat message to a Helium server and get a reply. Its prmary use is to
- * ensure that the connection doesn't time out due to NAT traversal. This feature is not mandatory,
- * but as Helium cannot by itself know when to send these, it is up to the host application to call
- * this function at the required intervals.
+ * This is used to send a heartbeat message to a Helium server and get a reply. Its primary use is
+ * to ensure that the connection doesn't time out due to NAT traversal. This feature is not
+ * mandatory, but as Helium cannot by itself know when to send these, it is up to the host
+ * application to call this function at the required intervals.
  */
 he_return_code_t he_conn_send_keepalive(he_conn_t *conn);
 
@@ -1228,7 +1229,7 @@ bool he_conn_is_error_fatal(he_conn_t *conn, he_return_code_t error_msg);
 he_return_code_t he_conn_rotate_session_id(he_conn_t *conn, uint64_t *new_session_id);
 
 /**
- * @brief Whether this particular connection supports renegoation
+ * @brief Whether this particular connection supports renegotiation
  *
  * Only pre-Dec 2020 clients won't support this.
  */

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -332,7 +332,7 @@ he_return_code_t he_conn_disconnect(he_conn_t *conn) {
 
   // Return error if in the wrong state
   if(conn->state == HE_STATE_DISCONNECTING || conn->state == HE_STATE_NONE ||
-      conn->state == HE_STATE_CONNECTING || conn->state == HE_STATE_DISCONNECTED) {
+     conn->state == HE_STATE_CONNECTING || conn->state == HE_STATE_DISCONNECTED) {
     return HE_ERR_INVALID_CONN_STATE;
   }
 

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -54,7 +54,7 @@
  * @note This function allocates memory
  *
  * This function must be called to create the initial Helium connection
- * for use with other functions
+ * for use with other functions.
  */
 he_conn_t *he_conn_create(void);
 
@@ -76,7 +76,8 @@ void he_conn_destroy(he_conn_t *conn);
  * @return HE_ERR_CONF_USERNAME_NOT_SET The username has not been set
  * @return HE_ERR_CONF_PASSWORD_NOT_SET The password has not been set
  * @return HE_ERR_CONF_MTU_NOT_SET The external MTU has not been set
- * @return HE_ERR_INCORRECT_PROTOCOL_VERSION The protocol version has been set
+ * @return HE_ERR_INCORRECT_PROTOCOL_VERSION The protocol version has been set but it's not equal to
+ * the maximum supported version defined in the ssl_ctx
  * @return HE_SUCCESS The basic configuration options have been set
  *
  * @note These return codes are similar to `he_conn_client_connect` because that function will call
@@ -201,7 +202,7 @@ int he_conn_set_outside_mtu(he_conn_t *conn, int mtu);
 
 /**
  * @brief Get the MTU value for the outside transport mechanism.
- * *@param conn A pointer to a valid connection.
+ * @param conn A pointer to a valid connection.
  * @ return int The MTU value in bytes.
  */
 int he_conn_get_outside_mtu(he_conn_t *conn);
@@ -320,10 +321,10 @@ he_return_code_t he_internal_send_auth(he_conn_t *conn);
  * @param conn A pointer to a valid connection
  * @return HE_SUCCESS Keep alive was sent
  *
- * This is used to send a heartbeat message to a Helium server and get a reply. Its prmary use is to
- * ensure that the connection doesn't time out due to NAT traversal. This feature is not mandatory,
- * but as Helium cannot by itself know when to send these, it is up to the host application to call
- * this function at the required intervals.
+ * This is used to send a heartbeat message to a Helium server and get a reply. Its primary use is
+ * to ensure that the connection doesn't time out due to NAT traversal. This feature is not
+ * mandatory, but as Helium cannot by itself know when to send these, it is up to the host
+ * application to call this function at the required intervals.
  */
 he_return_code_t he_conn_send_keepalive(he_conn_t *conn);
 
@@ -340,7 +341,7 @@ he_return_code_t he_conn_schedule_renegotiation(he_conn_t *conn);
 he_return_code_t he_internal_renegotiate_ssl(he_conn_t *conn);
 
 /**
- * @brief Updates the timeout for a connectionand triggers the timeout callback if set
+ * @brief Updates the timeout for a connection and triggers the timeout callback if set
  * @param conn A pointer to a valid connection
  */
 void he_internal_update_timeout(he_conn_t *conn);
@@ -422,7 +423,7 @@ bool he_conn_is_error_fatal(he_conn_t *conn, he_return_code_t error_msg);
 he_return_code_t he_conn_rotate_session_id(he_conn_t *conn, uint64_t *new_session_id);
 
 /**
- * @brief Whether this particular connection supports renegoation
+ * @brief Whether this particular connection supports renegotiation
  *
  * Only pre-Dec 2020 clients won't support this.
  */

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -871,7 +871,7 @@ void test_he_conn_set_protocol_version_null_conn(void) {
 void test_he_conn_is_error_fatal_streaming(void) {
   bool res = false;
   conn.connection_type = HE_CONNECTION_TYPE_STREAM;
-  for(int i = 0; i >= HE_ERR_INCORRECT_PROTOCOL_VERSION; i--) {
+  for(int i = 0; i >= HE_ERR_INVALID_AUTH_TYPE; i--) {
     switch(i) {
       case HE_SUCCESS:
       case HE_ERR_SSL_ERROR_NONFATAL:
@@ -890,7 +890,7 @@ void test_he_conn_is_error_fatal_streaming(void) {
 void test_he_conn_is_error_fatal_code_for_datagram(void) {
   bool res = false;
   conn.connection_type = HE_CONNECTION_TYPE_DATAGRAM;
-  for(int i = 0; i >= HE_ERR_INCORRECT_PROTOCOL_VERSION; i--) {
+  for(int i = 0; i >= HE_ERR_INVALID_AUTH_TYPE; i--) {
     switch(i) {
       case HE_SUCCESS:
       case HE_ERR_INVALID_CONN_STATE:
@@ -901,7 +901,6 @@ void test_he_conn_is_error_fatal_code_for_datagram(void) {
       case HE_ERR_EMPTY_PACKET:
       case HE_ERR_PACKET_TOO_SMALL:
       case HE_ERR_NOT_HE_PACKET:
-      case HE_ERR_UNSUPPORTED_PACKET_TYPE:
       case HE_ERR_BAD_PACKET:
       case HE_ERR_UNKNOWN_SESSION:
       case HE_ERR_INCORRECT_PROTOCOL_VERSION:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a packet contains incorrect protocol version, regardless the direction, the client/server should treat it as a fatal error and disconnect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`