### PR TITLE
ios: Fix builds for older iPhones

### DIFF
--- a/ios/autotools-ios-helper.sh
+++ b/ios/autotools-ios-helper.sh
@@ -63,8 +63,8 @@ build_iphoneos() {
     PLATFORM="iphoneos"
     ARCH_OPTS="--enable-armasm --enable-sp-asm"
     ARCH_FLAGS="-arch arm64"
-    HOST_FLAGS="${ARCH_FLAGS} -mfpu=auto -miphoneos-version-min=${MIN_IOS_VERSION} -isysroot $(xcrun --sdk ${SDK} --show-sdk-path)"
-    CHOST="aarch64-apple-darwin"
+    HOST_FLAGS="${ARCH_FLAGS} -miphoneos-version-min=${MIN_IOS_VERSION} -isysroot $(xcrun --sdk ${SDK} --show-sdk-path)"
+    CHOST="arm64-apple-ios"
     build
 }
 


### PR DESCRIPTION
The current target does not work on older iphones, The build will have SSL errors

This is due to wolfSSL changing their defaults. `--sp-math-all` is now the default implementation

The iphone tested here was an iphone 6S

<!--- Provide a general summary of your changes in the Title above -->

## Description
This option does not work for older iphones and will result in lack of ability to connect

## Motivation and Context
Without this change older iphones would not connect

## How Has This Been Tested?
Tested internally manually with an iPhone 6S

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`