### PR TITLE
conn: add method to get detailed SSL errors

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -1368,6 +1368,14 @@ he_return_code_t he_conn_set_protocol_version(he_conn_t *conn, uint8_t major_ver
 const char *he_conn_get_current_cipher(he_conn_t *conn);
 
 /**
+ * @brief Returns detailed SSL error that corresponds to WolfSSL's detailed errors
+ * @param conn A pointer to a valid server connection
+ * @return Integer that corresponds to a WolfSSL error or 0 if no detailed
+ * error is available
+ */
+int he_conn_get_ssl_error(he_conn_t *conn);
+
+/**
  * @brief Called when the host application needs to deliver an inside packet to Helium.
  * @param conn A valid connection
  * @param packet A pointer to the packet data

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -439,7 +439,12 @@ he_return_code_t he_internal_send_message(he_conn_t *conn, uint8_t *message, uin
         // continue.
         return HE_WANT_READ;
       default:
-        return (res == 0) ? HE_ERR_CONNECTION_WAS_CLOSED : HE_ERR_SSL_ERROR;
+        if (res == 0) {
+          return HE_ERR_CONNECTION_WAS_CLOSED;
+        } else {
+          conn->wolf_error = error;
+          return HE_ERR_SSL_ERROR;
+        }
     }
   }
 
@@ -661,6 +666,7 @@ he_return_code_t he_internal_renegotiate_ssl(he_conn_t *conn) {
         he_internal_update_timeout(conn);
         return HE_SUCCESS;
       default:
+        conn->wolf_error = error;
         return HE_ERR_SSL_ERROR;
     }
   }
@@ -1041,4 +1047,9 @@ const char *he_conn_get_current_cipher(he_conn_t *conn) {
     return wolfSSL_CIPHER_get_name(cipher);
   }
   return NULL;
+}
+
+
+int he_conn_get_ssl_error(he_conn_t* conn) {
+  return conn->wolf_error;
 }

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -447,4 +447,12 @@ he_return_code_t he_conn_set_protocol_version(he_conn_t *conn, uint8_t major_ver
  */
 const char *he_conn_get_current_cipher(he_conn_t *conn);
 
+/**
+ * @brief Returns detailed SSL error that corresponds to WolfSSL's detailed errors
+ * @param conn A pointer to a valid server connection
+ * @return Integer that corresponds to a WolfSSL error or 0 if no detailed
+ * error is available
+ */
+int he_conn_get_ssl_error(he_conn_t* conn);
+
 #endif  // CONN_H

--- a/src/he/core.c
+++ b/src/he/core.c
@@ -23,6 +23,7 @@ he_return_code_t he_internal_setup_stream_state(he_conn_t *conn, uint8_t *data, 
   if(conn->incoming_data_left_to_read != 0) {
     // Somehow this function was called without reading all data from a previous buffer
     // This is bad
+    conn->wolf_error = 0;
     return HE_ERR_SSL_ERROR;
   }
   // Set up the location of the buffer and its length

--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -119,6 +119,7 @@ he_return_code_t he_internal_flow_process_message(he_conn_t *conn) {
   // very wrong with the SSL connection
   if(conn->read_packet.packet_size < sizeof(he_msg_hdr_t)) {
     conn->read_packet.has_packet = false;
+    conn->wolf_error = 0;
     return HE_ERR_SSL_ERROR;
   }
 
@@ -215,8 +216,12 @@ he_return_code_t he_internal_flow_fetch_message(he_conn_t *conn) {
         } else {
           // if this is TCP then any SSL error is fatal (stream corruption).
           // If this is D/TLS we can actually ignore corrupted packets.
-          return conn->connection_type == HE_CONNECTION_TYPE_STREAM ? HE_ERR_SSL_ERROR
-                                                                    : HE_ERR_SSL_ERROR_NONFATAL;
+          if (conn->connection_type == HE_CONNECTION_TYPE_STREAM) {
+            conn->wolf_error = error;
+            return HE_ERR_SSL_ERROR;
+          } else {
+            return HE_ERR_SSL_ERROR_NONFATAL;
+          }
         }
     }
   } else {
@@ -391,6 +396,7 @@ he_return_code_t he_internal_flow_outside_data_verify_connection(he_conn_t *conn
           return HE_ERR_SERVER_DN_MISMATCH;
         }
 
+        conn->wolf_error = error;
         // We can't recover from any other errors
         return HE_ERR_SSL_ERROR;
       }

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -133,6 +133,8 @@ struct he_conn {
   WOLFSSL *wolf_ssl;
   /// Wolf Timeout
   int wolf_timeout;
+  /// Wolf last error
+  int wolf_error;
   /// Write buffer
   uint8_t write_buffer[HE_MAX_WIRE_MTU];
   /// Packet seen

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -688,6 +688,7 @@ void test_he_internal_send_message_ssl_error(void) {
   wolfSSL_get_error_ExpectAndReturn(conn.wolf_ssl, -1, SSL_FATAL_ERROR);
   int rc = he_internal_send_message(&conn, fake_ipv4_packet, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_ERR_SSL_ERROR, rc);
+  TEST_ASSERT_EQUAL(SSL_FATAL_ERROR, conn.wolf_error);
 }
 
 void test_he_internal_update_timeout_with_cb_multiple_calls(void) {
@@ -1063,6 +1064,7 @@ void test_he_internal_renegotiate_ssl_error_fatal(void) {
 
   he_return_code_t res = he_internal_renegotiate_ssl(&conn);
   TEST_ASSERT_EQUAL(HE_ERR_SSL_ERROR, res);
+  TEST_ASSERT_EQUAL(SSL_FATAL_ERROR, conn.wolf_error);
 }
 
 void test_he_conn_server_connect_null_pointers(void) {
@@ -1420,4 +1422,11 @@ void test_he_conn_get_current_cipher(void) {
   wolfSSL_get_current_cipher_ExpectAndReturn(conn.wolf_ssl, mock_cipher);
   wolfSSL_CIPHER_get_name_ExpectAndReturn(mock_cipher, "mycipher");
   TEST_ASSERT_EQUAL_STRING("mycipher", he_conn_get_current_cipher(&conn));
+}
+
+void test_he_conn_get_ssl_error(void) {
+  conn.wolf_error = -1;
+  TEST_ASSERT_EQUAL(-1, he_conn_get_ssl_error(&conn));
+  conn.wolf_error = -2;
+  TEST_ASSERT_EQUAL(-2, he_conn_get_ssl_error(&conn));
 }

--- a/test/he/test_core.c
+++ b/test/he/test_core.c
@@ -41,4 +41,5 @@ void test_he_internal_stream_setup_state_overwrite(void) {
   int res = he_internal_setup_stream_state(conn, empty_data, sizeof(empty_data));
 
   TEST_ASSERT_EQUAL(HE_ERR_SSL_ERROR, res);
+  TEST_ASSERT_EQUAL(0, conn->wolf_error);
 }

--- a/test/he/test_flow.c
+++ b/test/he/test_flow.c
@@ -618,6 +618,8 @@ void test_he_internal_flow_process_message_too_small(void) {
 
   int res = he_internal_flow_process_message(conn);
   TEST_ASSERT_EQUAL(HE_ERR_SSL_ERROR, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->wolf_error);
 }
 
 void test_he_internal_flow_process_message_null_conn(void) {
@@ -629,6 +631,72 @@ void test_he_internal_flow_fetch_message_null_conn(void) {
   int res = he_internal_flow_fetch_message(NULL);
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
 }
+
+void test_he_internal_flow_fetch_message_success(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), 10);
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+  TEST_ASSERT_TRUE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(10, conn->read_packet.packet_size);
+}
+
+void test_he_internal_flow_fetch_message_error_none(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), 0);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, 0, SSL_ERROR_NONE);
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->read_packet.packet_size);
+}
+
+void test_he_internal_flow_fetch_message_error_want_read(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), 0);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, 0, SSL_ERROR_WANT_READ);
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->read_packet.packet_size);
+}
+
+void test_he_internal_flow_fetch_message_error_want_write(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), 0);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, 0, SSL_ERROR_WANT_WRITE);
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->read_packet.packet_size);
+}
+
+void test_he_internal_flow_fetch_message_error_conn_closed(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), 0);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, 0, SSL_ERROR_SSL);
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_ERR_CONNECTION_WAS_CLOSED, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->read_packet.packet_size);
+}
+
+void test_he_internal_flow_fetch_message_error_non_fatal(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), -1);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, -1, SSL_ERROR_SSL);
+  conn->connection_type = HE_CONNECTION_TYPE_DATAGRAM;
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_ERR_SSL_ERROR_NONFATAL, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->read_packet.packet_size);
+}
+
+void test_he_internal_flow_fetch_message_error_fatal(void) {
+  wolfSSL_read_ExpectAndReturn(conn->wolf_ssl, conn->read_packet.packet, sizeof(conn->read_packet.packet), -1);
+  wolfSSL_get_error_ExpectAndReturn(conn->wolf_ssl, -1, SSL_ERROR_SSL);
+  conn->connection_type = HE_CONNECTION_TYPE_STREAM;
+  int res = he_internal_flow_fetch_message(conn);
+  TEST_ASSERT_EQUAL(HE_ERR_SSL_ERROR, res);
+  TEST_ASSERT_FALSE(conn->read_packet.has_packet);
+  TEST_ASSERT_EQUAL(0, conn->read_packet.packet_size);
+  TEST_ASSERT_EQUAL(SSL_ERROR_SSL, conn->wolf_error);
+}
+
 // In general we try to avoid complex macros in libhelium, but these tests are so repetitive the
 // value of capturing these lines
 #define HE_MSG_SWITCH_TEST(test_msgid)          \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add additional method for wolfSSL errors

## Motivation and Context
This allows us to get detailed SSL errors to ease debugging

## How Has This Been Tested?
Has autotests, this was also used to help debug issues internally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`