### PR TITLE
Add new message type: HE_MSGID_SERVER_CONFIG

### DIFF
--- a/include/he.h
+++ b/include/he.h
@@ -338,6 +338,21 @@ typedef he_return_code_t (*he_network_config_ipv4_cb_t)(he_conn_t *conn,
                                                         void *context);
 
 /**
+ * @brief The prototype for the server config callback function
+ * @param conn A pointer to the connection that triggered this callback
+ * @param buffer A pointer to the buffer containing the server configuration data
+ * @param length The length of the buffer
+ * @param context A pointer to the user defined context
+ * @see he_conn_set_context Sets the value of the context pointer
+ *
+ * Whenever the client receives the server configuration data (pushed by the Helium server), this
+ * callback will be triggered. The host application is responsible for parsing the data using
+ * implementation specific format.
+ */
+typedef he_return_code_t (*he_server_config_cb_t)(he_conn_t *conn, uint8_t *buffer, size_t length,
+                                                  void *context);
+
+/**
  * @brief The prototype for the event callback function
  * @param conn A pointer to the connection that triggered this callback
  * @param event The event to trigger
@@ -458,6 +473,8 @@ struct he_ssl_ctx {
   he_outside_write_cb_t outside_write_cb;
   /// Network config callback
   he_network_config_ipv4_cb_t network_config_ipv4_cb;
+  /// Server config callback
+  he_server_config_cb_t server_config_cb;
   /// Nudge timer
   he_nudge_time_cb_t nudge_time_cb;
   // Callback for events
@@ -561,6 +578,8 @@ struct he_conn {
   he_outside_write_cb_t outside_write_cb;
   /// Network config callback
   he_network_config_ipv4_cb_t network_config_ipv4_cb;
+  /// Server config callback
+  he_server_config_cb_t server_config_cb;
   // Callback for events
   he_event_cb_t event_cb;
   // Callback for auth (server-only)
@@ -608,7 +627,9 @@ typedef enum msg_ids {
   /// Tell the other side that we're closing down
   HE_MSGID_GOODBYE = 12,
   /// Deprecated message - same as Data packet with an unused int flag
-  HE_MSGID_DEPRECATED_13 = 13
+  HE_MSGID_DEPRECATED_13 = 13,
+  /// Server configuration data pushed to the client by the server
+  HE_MSGID_SERVER_CONFIG = 14,
 } msg_ids_t;
 
 typedef enum he_auth_type {
@@ -684,6 +705,12 @@ typedef struct he_msg_auth_buf {
   uint16_t buffer_length;
   uint8_t buffer[];
 } he_msg_auth_buf_t;
+
+typedef struct he_msg_server_config {
+  he_msg_hdr_t msg_header;
+  uint16_t buffer_length;
+  uint8_t buffer[];
+} he_msg_server_config_t;
 
 typedef struct he_msg_config_ipv4 {
   he_msg_hdr_t msg_header;

--- a/public/he.h
+++ b/public/he.h
@@ -310,6 +310,21 @@ typedef he_return_code_t (*he_network_config_ipv4_cb_t)(he_conn_t *conn,
                                                         void *context);
 
 /**
+ * @brief The prototype for the server config callback function
+ * @param conn A pointer to the connection that triggered this callback
+ * @param buffer A pointer to the buffer containing the server configuration data
+ * @param length The length of the buffer
+ * @param context A pointer to the user defined context
+ * @see he_conn_set_context Sets the value of the context pointer
+ *
+ * Whenever the client receives the server configuration data (pushed by the Helium server), this
+ * callback will be triggered. The host application is responsible for parsing the data using
+ * implementation specific format.
+ */
+typedef he_return_code_t (*he_server_config_cb_t)(he_conn_t *conn, uint8_t *buffer, size_t length,
+                                                  void *context);
+
+/**
  * @brief The prototype for the event callback function
  * @param conn A pointer to the connection that triggered this callback
  * @param event The event to trigger
@@ -776,6 +791,15 @@ void he_ssl_ctx_set_network_config_ipv4_cb(he_ssl_ctx_t *ctx,
 bool he_ssl_ctx_is_network_config_ipv4_cb_set(he_ssl_ctx_t *ctx);
 
 /**
+ * @brief Sets the function that will be called when Helium needs to pass server config to the host
+ * application.
+ * @param ctx A pointer to a valid SSL context
+ * @param network_config_cb The function to be called when Helium needs to pass server config
+ * to the host application.
+ */
+void he_ssl_ctx_set_server_config_cb(he_ssl_ctx_t *ctx, he_server_config_cb_t server_config_cb);
+
+/**
  * @brief Sets the function that will be called when Helium needs to update the nudge time.
  * @param ctx A pointer to a valid SSL context
  * @param nudge_time_cb The function to be called when Helium needs to update the nudge time
@@ -1140,6 +1164,16 @@ he_return_code_t he_conn_disconnect(he_conn_t *conn);
  * application to call this function at the required intervals.
  */
 he_return_code_t he_conn_send_keepalive(he_conn_t *conn);
+
+/**
+ * @brief Tell Helium to send a server config message to client.
+ * @param conn A pointer to a valid connection
+ * @return HE_SUCCESS the server config was sent
+ *
+ * This is used to send a server config message to a Helium client from server. The server must have
+already established the TLS connection, but it's OK the client is not authenticated yet.
+*/
+he_return_code_t he_conn_send_server_config(he_conn_t *conn, uint8_t *buffer, size_t length);
 
 /**
  * @brief Tell Helium to schedule a renegotiation

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -329,6 +329,18 @@ he_return_code_t he_internal_send_auth(he_conn_t *conn);
 he_return_code_t he_conn_send_keepalive(he_conn_t *conn);
 
 /**
+ * @brief Tell Helium to send a server config message to client.
+ * @param conn A pointer to a valid connection
+ * @return HE_SUCCESS the server config was sent
+ *
+ * This is used to send a server config message to a Helium client from server. The server must have
+already established the TLS connection, but it's OK the client is not authenticated yet.
+*/
+he_return_code_t he_conn_send_server_config(he_conn_t *conn, uint8_t *buffer, size_t length);
+
+bool he_internal_is_valid_state_for_server_config(he_conn_t *conn);
+
+/**
  * @brief Tell Helium to schedule a renegotiation
  * @param conn A pointer to a valid connection
  * @return HE_SUCCESS A renegotiation is scheduled.

--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -165,6 +165,12 @@ he_return_code_t he_internal_flow_process_message(he_conn_t *conn) {
       return HE_SUCCESS;
     case HE_MSGID_DEPRECATED_13:
       return he_handle_msg_deprecated_13(conn, buf, buf_len);
+    case HE_MSGID_SERVER_CONFIG:
+      if(!conn->is_server) {
+        return he_handle_msg_server_config(conn, buf, buf_len);
+      }
+      // Otherwise do nothing
+      return HE_SUCCESS;
     default:
       // Invalid message - just ignore it
       break;

--- a/src/he/msg_handlers.h
+++ b/src/he/msg_handlers.h
@@ -38,6 +38,7 @@ he_return_code_t he_handle_msg_auth_response_with_config(he_conn_t *conn, uint8_
                                                          int length);
 he_return_code_t he_handle_msg_deprecated_13(he_conn_t *conn, uint8_t *packet, int length);
 he_return_code_t he_handle_msg_goodbye(he_conn_t *conn, uint8_t *packet, int length);
+he_return_code_t he_handle_msg_server_config(he_conn_t *conn, uint8_t *packet, int length);
 
 bool he_internal_is_ipv4_packet_valid(uint8_t *packet, int length);
 

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -517,6 +517,15 @@ void he_ssl_ctx_set_network_config_ipv4_cb(he_ssl_ctx_t *ctx,
   ctx->network_config_ipv4_cb = network_config_ipv4_cb;
 }
 
+void he_ssl_ctx_set_server_config_cb(he_ssl_ctx_t *ctx, he_server_config_cb_t server_config_cb) {
+  // Return if ctx is null
+  if(!ctx) {
+    return;
+  }
+
+  ctx->server_config_cb = server_config_cb;
+}
+
 bool he_ssl_ctx_is_network_config_ipv4_cb_set(he_ssl_ctx_t *ctx) {
   if(!ctx) {
     return false;

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -370,6 +370,15 @@ void he_ssl_ctx_set_network_config_ipv4_cb(he_ssl_ctx_t *ctx,
 bool he_ssl_ctx_is_network_config_ipv4_cb_set(he_ssl_ctx_t *ctx);
 
 /**
+ * @brief Sets the function that will be called when Helium needs to pass server config to the host
+ * application.
+ * @param ctx A pointer to a valid SSL context
+ * @param network_config_cb The function to be called when Helium needs to pass server config
+ * to the host application.
+ */
+void he_ssl_ctx_set_server_config_cb(he_ssl_ctx_t *ctx, he_server_config_cb_t server_config_cb);
+
+/**
  * @brief Sets the function that will be called when Helium needs to update the nudge time.
  * @param ctx A pointer to a valid SSL context
  * @param nudge_time_cb The function to be called when Helium needs to update the nudge time

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -721,6 +721,11 @@ void test_set_network_config_ipv4_cb(void) {
   TEST_ASSERT_EQUAL(network_config_ipv4_cb, ctx->network_config_ipv4_cb);
 }
 
+void test_set_server_config_cb(void) {
+  he_ssl_ctx_set_server_config_cb(ctx, server_config_cb);
+  TEST_ASSERT_EQUAL(server_config_cb, ctx->server_config_cb);
+}
+
 void test_set_inside_write_cb(void) {
   he_ssl_ctx_set_inside_write_cb(ctx, write_cb);
   TEST_ASSERT_EQUAL(write_cb, ctx->inside_write_cb);

--- a/test/support/test_defs.h
+++ b/test/support/test_defs.h
@@ -53,6 +53,12 @@ he_return_code_t network_config_ipv4_cb(he_conn_t *conn, he_network_config_ipv4_
   return HE_SUCCESS;
 }
 
+he_return_code_t server_config_cb(he_conn_t *conn, uint8_t *buffer, size_t length,
+                                  void *context) {
+  call_counter++;
+  return HE_SUCCESS;
+}
+
 he_return_code_t state_change_cb(he_conn_t *conn, he_conn_state_t new_state, void *context) {
   call_counter++;
   return HE_SUCCESS;


### PR DESCRIPTION
## Description

This PR introduces a new message type `HE_MSGID_SERVER_CONFIG` to allow server pushing any server configuation data to client through the TLS connection.

On the server side, the server can call `he_conn_send_server_config` any time after the state has changed to `LINK_UP`. 
On the client side, the client can set the `he_server_config_cb_t` callback on the connection context to handle this message. This is optional.
The format of server config data is completely opaque to the Lightway Core. It's up to the implementation to define.

## How Has This Been Tested?
This change is unit tested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`