### PR TITLE
Make default constants public and bump maximum wire protocol version to 1.2

### DIFF
--- a/include/he.h
+++ b/include/he.h
@@ -47,20 +47,18 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/random.h>
 
-// Helper macros
+/** Begin Public Section **/
 
-/** Set sizes **/
+/// Default MTU sizes
 #define HE_MAX_WIRE_MTU 1500
 #define HE_MAX_MTU 1350
 #define HE_MAX_MTU_STR "1350"
 
-/** Set Maximum and Minimum Minor Versions **/
+/// Default minimum and maximum wire protocol versions
 #define HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION 1
 #define HE_WIRE_MINIMUM_PROTOCOL_MINOR_VERSION 0
 #define HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION 1
-#define HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION 1
-
-/** Begin Public Section **/
+#define HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION 2
 
 /// Helpful deprecation macro
 #ifdef __GNUC__
@@ -558,7 +556,7 @@ struct he_conn {
 
   void *data;
 
-  // Data from the SSL contxt config copied here to make this hermetic
+  // Data from the SSL context config copied here to make this hermetic
   /// Don't send session ID in packet header
   bool disable_roaming_connections;
   /// Which padding type to use
@@ -604,7 +602,7 @@ struct he_plugin_chain {
 typedef enum msg_ids {
   /// NOOP - nothing to do
   HE_MSGID_NOOP = 1,
-  /// Ping reqest
+  /// Ping request
   HE_MSGID_PING = 2,
   /// Pong - response to a Ping request
   HE_MSGID_PONG = 3,

--- a/public/he.h
+++ b/public/he.h
@@ -34,6 +34,17 @@
 // Helper macros
 #include "he_plugin.h"
 
+/// Default MTU sizes
+#define HE_MAX_WIRE_MTU 1500
+#define HE_MAX_MTU 1350
+#define HE_MAX_MTU_STR "1350"
+
+/// Default minimum and maximum wire protocol versions
+#define HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION 1
+#define HE_WIRE_MINIMUM_PROTOCOL_MINOR_VERSION 0
+#define HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION 1
+#define HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION 2
+
 /// Helpful deprecation macro
 #ifdef __GNUC__
 #define HE_DEPRECATED(name) __attribute__((deprecated("use " #name " instead")))
@@ -536,7 +547,7 @@ void he_ssl_ctx_destroy(he_ssl_ctx_t *ctx);
  * @return HE_ERR_SSL_CERT Generic failure in the SSL engine
  * @return HE_SUCCESS Helium is in the process of connecting
  *
- * This function has a lot of return codes as it is where Helium tries to apply and ctxure the
+ * This function has a lot of return codes as it is where Helium tries to apply and configure the
  * crypto engine. All of the return codes except for HE_SUCCESS are effectively fatal errors. Trying
  * to call *he_ssl_ctx_start_* again without changing the configuration is unlikely to succeed.
  */
@@ -557,14 +568,14 @@ he_return_code_t he_ssl_ctx_start(he_ssl_ctx_t *context);
  * @return HE_ERR_SSL_CERT Generic failure in the SSL engine
  * @return HE_SUCCESS Helium is in the process of connecting
  *
- * This function has a lot of return codes as it is where Helium tries to apply and ctxure the
+ * This function has a lot of return codes as it is where Helium tries to apply and configure the
  * crypto engine. All of the return codes except for HE_SUCCESS are effectively fatal errors. Trying
  * to call *he_ssl_ctx_start_* again without changing the configuration is unlikely to succeed.
  */
 he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *context);
 
 /**
- * @brief Try to cleanly stop the SSL contxt
+ * @brief Try to cleanly stop the SSL context
  * @param context A pointer to a valid SSL context (client or server)
  * @return HE_SUCCESS The disconnect process has started
  * @note This function is not yet well described and is likely to change

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -32,14 +32,14 @@
  * D/TLS is a UDP based protocol and requires the application
  * (rather than the OS as with TCP) to keep track of the need to do
  * retransmits on packet loss.
- * 
+ *
  * Currently Wolf has timeouts based in seconds. However this is not
  * sufficient for our goal of sub-second connection times.
- * 
+ *
  * As WolfSSL lacks millisecond timers we use its internal timers but
  * change its definition to be in 100 millisecond intervals instead of
  * seconds. So a wolf timeout of 1 second means 100 milliseconds.
- * 
+ *
  * By default wolf's DTLS max timeout is 64 seconds which translates to
  * 6.4 seconds. Since it scales from 1 to 64 by a factor
  * of 2 each timeout. The total timeout is 12.7 seconds with this scaling

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -311,7 +311,7 @@ bool he_ssl_ctx_is_supported_version(he_ssl_ctx_t *context, uint8_t major_versio
   // or maximum we check the minor version.
 
   // If the major version is between the minimum and maximum without equaling either
-  // the minor version is irrelvant, 3.x is between 2.0 and 4.0 regardless of what `x` equals.
+  // the minor version is irrelevant, 3.x is between 2.0 and 4.0 regardless of what `x` equals.
 
   if(major_version == context->minimum_supported_version.major_version &&
      minor_version < context->minimum_supported_version.minor_version) {

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -114,7 +114,7 @@ void he_ssl_ctx_destroy(he_ssl_ctx_t *ctx);
  * @return HE_ERR_SSL_CERT Generic failure in the SSL engine
  * @return HE_SUCCESS Helium is in the process of connecting
  *
- * This function has a lot of return codes as it is where Helium tries to apply and ctxure the
+ * This function has a lot of return codes as it is where Helium tries to apply and configure the
  * crypto engine. All of the return codes except for HE_SUCCESS are effectively fatal errors. Trying
  * to call *he_ssl_ctx_start_* again without changing the configuration is unlikely to succeed.
  */
@@ -135,14 +135,14 @@ he_return_code_t he_ssl_ctx_start(he_ssl_ctx_t *context);
  * @return HE_ERR_SSL_CERT Generic failure in the SSL engine
  * @return HE_SUCCESS Helium is in the process of connecting
  *
- * This function has a lot of return codes as it is where Helium tries to apply and ctxure the
+ * This function has a lot of return codes as it is where Helium tries to apply and configure the
  * crypto engine. All of the return codes except for HE_SUCCESS are effectively fatal errors. Trying
  * to call *he_ssl_ctx_start_* again without changing the configuration is unlikely to succeed.
  */
 he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *context);
 
 /**
- * @brief Try to cleanly stop the SSL contxt
+ * @brief Try to cleanly stop the SSL context
  * @param context A pointer to a valid SSL context (client or server)
  * @return HE_SUCCESS The disconnect process has started
  * @note This function is not yet well described and is likely to change

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -39,10 +39,10 @@
 // "Empty" ctx
 he_ssl_ctx_t *ctx;
 
-// "Properly ctxured" ctx
+// "Properly configured" ctx
 he_ssl_ctx_t *ctx2;
 
-// "Properly ctxured" ctx for server
+// "Properly configured" ctx for server
 he_ssl_ctx_t *ctx3;
 
 WOLFSSL_CTX *wolf_ctx;


### PR DESCRIPTION
...and fixed some minor typos.

## Motivation and Context
Previous [PR](https://github.com/expressvpn/lightway-core/pull/58) introduced a change to the wire protocol, therefore we should bump the wire protocol version too.

We should also make the constants available to implementations.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`