### PR TITLE
Add helper functions for setting min/max supported wire protocol versions on ssl_ctx

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -583,7 +583,36 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *context);
 he_return_code_t he_ssl_ctx_stop(he_ssl_ctx_t *context);
 
 /**
+ * @brief Set the minimum supported wire protocol version by this SSL context
+ * @param context A pointer to a valid SSL context
+ * @param major_version The major version of the minimum supported protocol version
+ * @param minor_version The minor version of the minimum supported protocol version
+ * @return HE_SUCCESS if the support version is set successfully
+ * @return HE_ERR_NULL_POINTER if the given SSL context is NULL
+ * @return HE_ERR_INCORRECT_PROTOCOL_VERSION if the new version is not valid
+ * @note This function is for server-side only.
+ */
+he_return_code_t he_ssl_ctx_set_minimum_supported_version(he_ssl_ctx_t *context,
+                                                          uint8_t major_version,
+                                                          uint8_t minor_version);
+
+/**
+ * @brief Set the maximum supported wire protocol version by this SSL context
+ * @param context A pointer to a valid SSL context
+ * @param major_version The major version of the maximum supported protocol version
+ * @param minor_version The minor version of the maximum supported protocol version
+ * @return HE_SUCCESS if the support version is set successfully
+ * @return HE_ERR_NULL_POINTER if the given SSL context is NULL
+ * @return HE_ERR_INCORRECT_PROTOCOL_VERSION if the new version is not valid
+ * @note This function is for server-side only
+ */
+he_return_code_t he_ssl_ctx_set_maximum_supported_version(he_ssl_ctx_t *context,
+                                                          uint8_t major_version,
+                                                          uint8_t minor_version);
+
+/**
  * @brief Validate whether a major/minor version is supported by this SSL context
+ * @param context A pointer to a valid SSL context
  * @param major_version The major version to test
  * @param minor_version The minor version to test
  * @return true if this SSL context supports this major/minor version, false otherwise
@@ -594,6 +623,7 @@ bool he_ssl_ctx_is_supported_version(he_ssl_ctx_t *context, uint8_t major_versio
 
 /**
  * @brief Validate whether the major/minor version is the latest
+ * @param context A pointer to a valid SSL context
  * @param major_version The major version to test
  * @param minor_version The minor version to test
  * @return true if this major/minor version is the latest supported by this context

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -293,6 +293,67 @@ he_return_code_t he_ssl_ctx_stop(he_ssl_ctx_t *context) {
   return HE_SUCCESS;
 }
 
+static bool he_is_valid_wire_protocol_version(uint8_t major_version, uint8_t minor_version) {
+  if(major_version < HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION ||
+     (major_version == HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION &&
+      minor_version < HE_WIRE_MINIMUM_PROTOCOL_MINOR_VERSION) ||
+     major_version > HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION ||
+     (major_version == HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION &&
+      minor_version > HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION)) {
+    return false;
+  }
+  return true;
+}
+
+he_return_code_t he_ssl_ctx_set_minimum_supported_version(he_ssl_ctx_t *context,
+                                                          uint8_t major_version,
+                                                          uint8_t minor_version) {
+  if(!context) {
+    return HE_ERR_NULL_POINTER;
+  }
+
+  // Use default value if both the major and minor versions are 0
+  if(major_version == 0 && minor_version == 0) {
+    major_version = HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION;
+    minor_version = HE_WIRE_MINIMUM_PROTOCOL_MINOR_VERSION;
+  }
+
+  // Validate the new version
+  if(!he_is_valid_wire_protocol_version(major_version, minor_version)) {
+    return HE_ERR_INCORRECT_PROTOCOL_VERSION;
+  }
+
+  // Set the minimum_supported_version
+  context->minimum_supported_version.major_version = major_version;
+  context->minimum_supported_version.minor_version = minor_version;
+  return HE_SUCCESS;
+}
+
+
+he_return_code_t he_ssl_ctx_set_maximum_supported_version(he_ssl_ctx_t *context,
+                                                          uint8_t major_version,
+                                                          uint8_t minor_version) {
+  if(!context) {
+    return HE_ERR_NULL_POINTER;
+  }
+
+  // Use default value if both the major and minor versions are 0
+  if(major_version == 0 && minor_version == 0) {
+    major_version = HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION;
+    minor_version = HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION;
+  }
+
+  // Validate the new version
+  if(!he_is_valid_wire_protocol_version(major_version, minor_version)) {
+    return HE_ERR_INCORRECT_PROTOCOL_VERSION;
+  }
+
+  // Set the maximum_supported_version
+  context->maximum_supported_version.major_version = major_version;
+  context->maximum_supported_version.minor_version = minor_version;
+  return HE_SUCCESS;
+}
+
 bool he_ssl_ctx_is_supported_version(he_ssl_ctx_t *context, uint8_t major_version,
                                      uint8_t minor_version) {
   // Return if ctx is null
@@ -634,6 +695,7 @@ he_padding_type_t he_ssl_ctx_get_padding_type(he_ssl_ctx_t *ctx) {
 
   return ctx->padding_type;
 }
+
 he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx) {
   // Return if ctx is null
   if(!ctx) {

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -150,7 +150,35 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *context);
 he_return_code_t he_ssl_ctx_stop(he_ssl_ctx_t *context);
 
 /**
+ * @brief Set the minimum supported wire protocol version by this SSL context
+ * @param context A pointer to a valid SSL context
+ * @param major_version The major version of the minimum supported protocol version
+ * @param minor_version The minor version of the minimum supported protocol version
+ * @return HE_SUCCESS if the support version is set successfully
+ * @return HE_ERR_NULL_POINTER if the given SSL context is NULL
+ * @return HE_ERR_INCORRECT_PROTOCOL_VERSION if the new version is not valid
+ * @note This function is for server-side only.
+ */
+he_return_code_t he_ssl_ctx_set_minimum_supported_version(he_ssl_ctx_t *context,
+                                                          uint8_t major_version,
+                                                          uint8_t minor_version);
+
+/**
+ * @brief Set the maximum supported wire protocol version by this SSL context
+ * @param context A pointer to a valid SSL context
+ * @param major_version The major version of the maximum supported protocol version
+ * @param minor_version The minor version of the maximum supported protocol version
+ * @return HE_SUCCESS if the support version is set successfully
+ * @return HE_ERR_NULL_POINTER if the given SSL context is NULL
+ * @return HE_ERR_INCORRECT_PROTOCOL_VERSION if the new version is not valid
+ * @note This function is for server-side only
+ */
+he_return_code_t he_ssl_ctx_set_maximum_supported_version(he_ssl_ctx_t *context,
+                                                          uint8_t major_version,
+                                                          uint8_t minor_version);
+/**
  * @brief Validate whether a major/minor version is supported by this SSL context
+ * @param context A pointer to a valid SSL context
  * @param major_version The major version to test
  * @param minor_version The minor version to test
  * @return true if this SSL context supports this major/minor version, false otherwise
@@ -161,6 +189,7 @@ bool he_ssl_ctx_is_supported_version(he_ssl_ctx_t *context, uint8_t major_versio
 
 /**
  * @brief Validate whether the major/minor version is the latest
+ * @param context A pointer to a valid SSL context
  * @param major_version The major version to test
  * @param minor_version The minor version to test
  * @return true if this major/minor version is the latest supported by this context

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -458,6 +458,69 @@ void test_he_server_connect_succeeds_streaming(void) {
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 }
 
+void test_he_ssl_ctx_set_minimum_supported_version(void) {
+  he_return_code_t rc = HE_ERR_FAILED;
+
+  // NULL pointer error
+  rc = he_ssl_ctx_set_minimum_supported_version(NULL, 0, 0);
+  TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, rc);
+
+  // Default value
+  rc = he_ssl_ctx_set_minimum_supported_version(ctx, 0, 0);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, rc);
+  TEST_ASSERT_EQUAL(HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION,
+                    ctx->minimum_supported_version.major_version);
+  TEST_ASSERT_EQUAL(HE_WIRE_MINIMUM_PROTOCOL_MINOR_VERSION,
+                    ctx->minimum_supported_version.minor_version);
+
+  // Invalid versions
+  rc =
+      he_ssl_ctx_set_minimum_supported_version(ctx, HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION - 1, 99);
+  TEST_ASSERT_EQUAL(HE_ERR_INCORRECT_PROTOCOL_VERSION, rc);
+  rc = he_ssl_ctx_set_minimum_supported_version(ctx, HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION + 1, 0);
+  TEST_ASSERT_EQUAL(HE_ERR_INCORRECT_PROTOCOL_VERSION, rc);
+  rc = he_ssl_ctx_set_minimum_supported_version(ctx, HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION,
+                                                HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION + 1);
+
+  // Valid version
+  rc = he_ssl_ctx_set_minimum_supported_version(ctx, 1, 1);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, rc);
+  TEST_ASSERT_EQUAL(1, ctx->minimum_supported_version.major_version);
+  TEST_ASSERT_EQUAL(1, ctx->minimum_supported_version.minor_version);
+}
+
+void test_he_ssl_ctx_set_maximum_supported_version(void) {
+  he_return_code_t rc = HE_ERR_FAILED;
+
+  // NULL pointer error
+  rc = he_ssl_ctx_set_maximum_supported_version(NULL, 0, 0);
+  TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, rc);
+
+  // Default value
+  rc = he_ssl_ctx_set_maximum_supported_version(ctx, 0, 0);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, rc);
+  TEST_ASSERT_EQUAL(HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION,
+                    ctx->maximum_supported_version.major_version);
+  TEST_ASSERT_EQUAL(HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION,
+                    ctx->maximum_supported_version.minor_version);
+
+  // Invalid versions
+  rc =
+      he_ssl_ctx_set_maximum_supported_version(ctx, HE_WIRE_MINIMUM_PROTOCOL_MAJOR_VERSION - 1, 99);
+  TEST_ASSERT_EQUAL(HE_ERR_INCORRECT_PROTOCOL_VERSION, rc);
+  rc = he_ssl_ctx_set_maximum_supported_version(ctx, HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION + 1, 0);
+  TEST_ASSERT_EQUAL(HE_ERR_INCORRECT_PROTOCOL_VERSION, rc);
+  rc = he_ssl_ctx_set_maximum_supported_version(ctx, HE_WIRE_MAXIMUM_PROTOCOL_MAJOR_VERSION,
+                                                HE_WIRE_MAXIMUM_PROTOCOL_MINOR_VERSION + 1);
+  TEST_ASSERT_EQUAL(HE_ERR_INCORRECT_PROTOCOL_VERSION, rc);
+
+  // Valid version
+  rc = he_ssl_ctx_set_maximum_supported_version(ctx, 1, 1);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, rc);
+  TEST_ASSERT_EQUAL(1, ctx->maximum_supported_version.major_version);
+  TEST_ASSERT_EQUAL(1, ctx->maximum_supported_version.minor_version);
+}
+
 void test_he_ssl_ctx_is_supported_version_same_minimum_version(void) {
   ctx->minimum_supported_version.major_version = 1;
   ctx->minimum_supported_version.minor_version = 0;
@@ -808,7 +871,6 @@ void test_he_ssl_ctx_is_auth_cb_set_ctx_null(void) {
   TEST_ASSERT_FALSE(res);
 }
 
-
 void test_he_ssl_ctx_set_auth_cb_ctx_null(void) {
   he_ssl_ctx_set_auth_cb(NULL, auth_cb);
 }
@@ -843,7 +905,6 @@ void test_he_ssl_ctx_is_ca_set_set_ctx_null(void) {
   TEST_ASSERT_FALSE(res);
 }
 
-
 void test_he_ssl_ctx_set_server_cert_key_files_ctx_null(void) {
   he_return_code_t res = he_ssl_ctx_set_server_cert_key_files(NULL, fake_cert, fake_cert);
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
@@ -855,10 +916,9 @@ void test_he_ssl_ctx_set_ca_ctx_null(void) {
 }
 
 void test_he_ssl_ctx_set_use_chacha20_ctx_null(void) {
-  he_return_code_t res = he_ssl_ctx_set_use_chacha20(NULL,true);
+  he_return_code_t res = he_ssl_ctx_set_use_chacha20(NULL, true);
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
 }
-
 
 void test_he_ssl_ctx_get_use_chacha20_ctx_null(void) {
   bool res = he_ssl_ctx_get_use_chacha20(NULL);
@@ -876,7 +936,7 @@ void test_he_ssl_ctx_get_server_dn_ctx_null(void) {
 }
 
 void test_he_ssl_ctx_set_server_dn_ctx_null(void) {
-  he_return_code_t res = he_ssl_ctx_set_server_dn(NULL,"dn");
+  he_return_code_t res = he_ssl_ctx_set_server_dn(NULL, "dn");
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
 }
 


### PR DESCRIPTION
## Motivation and Context
Allow server implementations to set the minimum / maximum supported wire protocol versions at runtime.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`