### PR TITLE
ssl: Set cipher list on servers

### DIFF
--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -265,10 +265,6 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
     return HE_ERR_INIT_FAILED;
   }
 
-  /* // 2020-03-15 Setting this currently causes chacha20 clients to misbehave, commenting out
-   * // while the team investigates
-   *
-   *
   // Explicitly set the cipher list
   if(ctx->connection_type == HE_CONNECTION_TYPE_STREAM) {
     res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx,
@@ -283,7 +279,6 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
   if(res != SSL_SUCCESS) {
     return HE_ERR_INIT_FAILED;
   }
-  */
 
   return he_ssl_ctx_start_common(ctx);
 }

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -426,6 +426,8 @@ void test_he_server_connect_succeeds(void) {
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
 
+  wolfSSL_CTX_set_cipher_list_IgnoreAndReturn(SSL_SUCCESS);
+
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_dtls_read);
   wolfSSL_CTX_SetIOSend_Expect(my_ctx, he_wolf_dtls_write);
@@ -449,6 +451,8 @@ void test_he_server_connect_succeeds_streaming(void) {
 
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
+
+  wolfSSL_CTX_set_cipher_list_IgnoreAndReturn(SSL_SUCCESS);
 
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_tls_read);


### PR DESCRIPTION
## Description
Set the ciphers offered by the servers

## Motivation and Context
This prevents any clients from attempting to connect with weak ciphers

## How Has This Been Tested?
Manually tested with internal tools

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`