### PR TITLE
conn: add a helper function for getting the cipher used by the current ssl session

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -1323,6 +1323,13 @@ he_return_code_t he_conn_set_protocol_version(he_conn_t *conn, uint8_t major_ver
                                               uint8_t minor_version);
 
 /**
+ * @brief Returns the name of the cipher used by the ssl context.
+ * @param ctx A pointer to a valid SSL context
+ * @return The string representation of the cipher
+ */
+const char *he_conn_get_current_cipher(he_conn_t *conn);
+
+/**
  * @brief Called when the host application needs to deliver an inside packet to Helium.
  * @param conn A valid connection
  * @param packet A pointer to the packet data

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -1006,3 +1006,14 @@ he_return_code_t he_conn_set_session_id(he_conn_t *conn, uint64_t session_id) {
   conn->session_id = session_id;
   return HE_SUCCESS;
 }
+
+const char *he_conn_get_current_cipher(he_conn_t *conn) {
+  if(!conn || !conn->wolf_ssl) {
+    return NULL;
+  }
+  WOLFSSL_CIPHER *cipher = wolfSSL_get_current_cipher(conn->wolf_ssl);
+  if(cipher) {
+    return wolfSSL_CIPHER_get_name(cipher);
+  }
+  return NULL;
+}

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -466,4 +466,11 @@ size_t he_internal_calculate_data_packet_length(he_conn_t *conn, size_t length);
  */
 he_return_code_t he_internal_generate_session_id(he_conn_t *conn, uint64_t *session_id_out);
 
+/**
+ * @brief Returns the name of the cipher used by the ssl context.
+ * @param ctx A pointer to a valid SSL context
+ * @return The string representation of the cipher
+ */
+const char *he_conn_get_current_cipher(he_conn_t *conn);
+
 #endif  // CONN_H

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -324,7 +324,6 @@ he_return_code_t he_ssl_ctx_set_minimum_supported_version(he_ssl_ctx_t *context,
   return HE_SUCCESS;
 }
 
-
 he_return_code_t he_ssl_ctx_set_maximum_supported_version(he_ssl_ctx_t *context,
                                                           uint8_t major_version,
                                                           uint8_t minor_version) {
@@ -437,7 +436,7 @@ bool he_ssl_ctx_get_use_chacha20(he_ssl_ctx_t *ctx) {
     return false;
   }
 
-  return (ctx->use_chacha);
+  return ctx->use_chacha;
 }
 
 he_return_code_t he_ssl_ctx_set_ca(he_ssl_ctx_t *ctx, uint8_t *cert_buffer, size_t length) {

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -1382,3 +1382,17 @@ void test_he_conn_send_server_config_packet_too_large(void) {
   ret = he_conn_send_server_config(&conn, empty_data, sizeof(empty_data));
   TEST_ASSERT_EQUAL(HE_ERR_PACKET_TOO_LARGE, ret);
 }
+
+void test_he_conn_get_current_cipher_null(void) {
+  TEST_ASSERT_NULL(he_conn_get_current_cipher(NULL));
+
+  conn.wolf_ssl = NULL;
+  TEST_ASSERT_NULL(he_conn_get_current_cipher(&conn));
+}
+
+void test_he_conn_get_current_cipher(void) {
+  WOLFSSL_CIPHER *mock_cipher = (WOLFSSL_CIPHER *)(uintptr_t)0xdeadbeef;
+  wolfSSL_get_current_cipher_ExpectAndReturn(conn.wolf_ssl, mock_cipher);
+  wolfSSL_CIPHER_get_name_ExpectAndReturn(mock_cipher, "mycipher");
+  TEST_ASSERT_EQUAL_STRING("mycipher", he_conn_get_current_cipher(&conn));
+}


### PR DESCRIPTION
## Description
Return the name of the cipher being used by current ssl session.

## Motivation and Context
Provide additional information for troubleshooting cipher related issues.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`