### PR TITLE
ci: fix linux build on arm architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Install Ceedling
         run: sudo gem install ceedling --no-user-install
       - name: Install ARM Tools
-        run: sudo apt install -y crossbuild-essential-arm64 qemu-user
+        run: |
+          sudo apt update
+          sudo apt install -y crossbuild-essential-arm64 qemu-user
       - name: Build dependencies
         run: CROSS_COMPILE="aarch64-linux-gnu" CC="aarch64-linux-gnu-gcc" ceedling project:linux_arm clobber dependencies:make
       - name: Run wolfSSL Tests
@@ -79,7 +81,9 @@ jobs:
       - name: Install Ceedling
         run: sudo gem install ceedling --no-user-install
       - name: Install ARM Tools
-        run: sudo apt install -y crossbuild-essential-armhf qemu-user
+        run: |
+          sudo apt update
+          sudo apt install -y crossbuild-essential-armhf qemu-user
       - name: Build dependencies
         run: CROSS_COMPILE="arm-linux-gnueabihf" CC="arm-linux-gnueabihf-gcc" ceedling project:linux_arm clobber dependencies:make
       - name: Run wolfSSL Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@
 name: CI
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   earthly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FORCE_COLOR: 1
     steps:
@@ -27,7 +27,7 @@ jobs:
       - name: Run build
         run: earthly --ci +all
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -41,7 +41,7 @@ jobs:
       - name: Run build and test
         run: ceedling project:linux
   linux-386:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -57,7 +57,7 @@ jobs:
       - name: Run build and test
         run: ceedling project:linux_386
   linux-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -73,7 +73,7 @@ jobs:
       - name: Run build
         run: CC="aarch64-linux-gnu-gcc" ceedling project:linux_arm release
   linux-arm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -149,7 +149,7 @@ jobs:
           cd ios/Lightway
           ./build-xcframework.sh
   android-armeabi-v7a:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -159,7 +159,7 @@ jobs:
           source android/android_env.sh armeabi-v7a
           ceedling project:android release
   android-arm64-v8a:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -169,7 +169,7 @@ jobs:
           source android/android_env.sh arm64-v8a
           ceedling project:android release
   android-x86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling
@@ -179,7 +179,7 @@ jobs:
           source android/android_env.sh x86
           ceedling project:android release
   android-x86_64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ceedling


### PR DESCRIPTION
## Description
Github Actions recently bumped the `ubuntu-latest` image to Ubuntu 22.04 which breaks our Linux builds on arms. This change pins the CI image to Ubuntu 20.04 and run `apt update` when installing arm build tools.

## How Has This Been Tested?
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`