### PR TITLE
Add SNI Support on client side

### DIFF
--- a/android.yml
+++ b/android.yml
@@ -19,7 +19,7 @@
         - LIBS=-llog -landroid
       :build:
         - autoreconf -i
-        - ./configure $CROSS_OPTS C_EXTRA_FLAGS="$C_EXTRA_FLAGS" --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs
+        - ./configure $CROSS_OPTS C_EXTRA_FLAGS="$C_EXTRA_FLAGS" --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni
         - make
         - make install
       :artifacts:

--- a/include/he.h
+++ b/include/he.h
@@ -71,6 +71,8 @@
 #define HE_CONFIG_TEXT_FIELD_LENGTH 50
 /// Maximum size of an IPV4 String
 #define HE_MAX_IPV4_STRING_LENGTH 24
+/// Maximum size of a hostname
+#define HE_MAX_HOSTNAME_LENGTH 255
 
 /**
  * @brief All possible return codes for helium
@@ -547,6 +549,9 @@ struct he_conn {
   char username[HE_CONFIG_TEXT_FIELD_LENGTH + 1];
   /// VPN password -- room for a null on the end
   char password[HE_CONFIG_TEXT_FIELD_LENGTH + 1];
+
+  /// SNI Hostname
+  char sni_hostname[HE_MAX_HOSTNAME_LENGTH + 1];
 
   uint8_t auth_buffer[HE_MAX_MTU];
   uint16_t auth_buffer_length;

--- a/ios/autotools-ios-helper.sh
+++ b/ios/autotools-ios-helper.sh
@@ -51,7 +51,8 @@ build() {
         --enable-secure-renegotiation \
         --disable-shared \
         --disable-examples \
-        --disable-sys-ca-certs
+        --disable-sys-ca-certs \
+        --enable-sni
 
     make clean
     mkdir -p "${EXEC_PREFIX}"

--- a/linux.yml
+++ b/linux.yml
@@ -18,7 +18,7 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs"
+        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"
         - "make install"
       :artifacts:

--- a/linux_386.yml
+++ b/linux_386.yml
@@ -19,7 +19,7 @@
         - LDFLAGS= -m32
       :build:
         - "autoreconf -i"
-        - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs"
+        - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"
         - "make install"
       :artifacts:

--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -18,7 +18,7 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
         - "autoreconf -i"
-        - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs"
+        - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"
         - "make install"
       :artifacts:

--- a/macos.yml
+++ b/macos.yml
@@ -19,7 +19,7 @@
         - CC=clang
       :build:
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs"
+        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"
         - "make install"
       :artifacts:

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -20,7 +20,7 @@
         - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
         - "autoreconf -i"
-        - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm --disable-examples --disable-sys-ca-certs"
+        - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"
         - "make install"
       :artifacts:

--- a/public/he.h
+++ b/public/he.h
@@ -56,6 +56,8 @@
 #define HE_CONFIG_TEXT_FIELD_LENGTH 50
 /// Maximum size of an IPV4 String
 #define HE_MAX_IPV4_STRING_LENGTH 24
+/// Maximum size of a hostname
+#define HE_MAX_HOSTNAME_LENGTH 255
 
 /**
  * @brief All possible return codes for helium
@@ -1126,6 +1128,16 @@ he_return_code_t he_conn_set_context(he_conn_t *conn, void *data);
  * @return void* The void pointer that was set previously or NULL if none was set
  */
 void *he_conn_get_context(he_conn_t *conn);
+
+/**
+ * @brief Set SNI hostname
+ * @param conn A valid connection
+ * @param hostname A null-terminated string contains the SNI hostname
+ *
+ * If the hostname is not empty, the client will enable SNI and set the hostname in the ClientHello
+ * message when connecting to the server. Available for TLS v1.3 only.
+ */
+he_return_code_t he_conn_set_sni_hostname(he_conn_t *conn, const char *hostname);
 
 /**
  * @brief Tries to establish a connection with a Helium server

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -234,7 +234,18 @@ he_return_code_t he_conn_set_context(he_conn_t *conn, void *data);
  * @return void* The void pointer that was set previously or NULL if none was set
  */
 void *he_conn_get_context(he_conn_t *conn);
+
 he_return_code_t he_internal_conn_configure(he_conn_t *conn, he_ssl_ctx_t *ctx);
+
+/**
+ * @brief Set SNI hostname
+ * @param conn A valid connection
+ * @param hostname A null-terminated string contains the SNI hostname
+ *
+ * If the hostname is not empty, the client will enable SNI and set the hostname in the ClientHello
+ * message when connecting to the server. Available for TLS v1.3 only.
+ */
+he_return_code_t he_conn_set_sni_hostname(he_conn_t *conn, const char *hostname);
 
 /**
  * @brief Tries to establish a connection with a Helium server

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -153,6 +153,29 @@ void test_conn_create_destroy(void) {
   he_conn_destroy(test_conn);
 }
 
+void test_set_sni_hostname(void) {
+  int res = he_conn_set_sni_hostname(&conn, good_hostname);
+  TEST_ASSERT_EQUAL_STRING(good_hostname, conn.sni_hostname);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+}
+
+void test_set_sni_hostname_with_empty_string(void) {
+  int res = he_conn_set_sni_hostname(&conn, "");
+  TEST_ASSERT_EQUAL_STRING("", conn.sni_hostname);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+}
+
+void test_set_sni_hostname_with_long_string(void) {
+  char *long_string =
+      "0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde."
+      "0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde."
+      "0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde."
+      "0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde.0123456789abcde.";
+  int res = he_conn_set_sni_hostname(&conn, long_string);
+  TEST_ASSERT_EQUAL(HE_MAX_HOSTNAME_LENGTH, strlen(conn.sni_hostname));
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+}
+
 void test_set_username(void) {
   int res = he_conn_set_username(&conn, good_username);
   TEST_ASSERT_EQUAL_STRING(good_username, conn.username);

--- a/test/support/test_defs.h
+++ b/test/support/test_defs.h
@@ -7,6 +7,7 @@ char *bad_string_too_long = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 char *good_username = "fsdfkjsfrwejkr";
 char *good_password = "dsgfdfgghgfhgf";
+char *good_hostname = "server1.expressvpn.com";
 
 uint8_t fake_cert[] = {0x10, 0x11, 0x12, 0x13, 0x14};
 


### PR DESCRIPTION
## Description
Enable SNI support in WolfSSL and add a new client API for setting the SNI hostname when initiating the TLS connection.

## How Has This Been Tested?
This feature is unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`