### PR TITLE
ssl: revert setting cipher on servers

### DIFF
--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -265,6 +265,11 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
     return HE_ERR_INIT_FAILED;
   }
 
+  /*
+    Commenting this out, the root cause is found out to be a WolfSSL bug.
+    TODO: To Uncomment when https://github.com/wolfSSL/wolfssl/pull/5932
+    is in a full release.
+
   // Explicitly set the cipher list
   if(ctx->connection_type == HE_CONNECTION_TYPE_STREAM) {
     res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx,
@@ -279,6 +284,7 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
   if(res != SSL_SUCCESS) {
     return HE_ERR_INIT_FAILED;
   }
+  */
 
   return he_ssl_ctx_start_common(ctx);
 }

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -426,8 +426,6 @@ void test_he_server_connect_succeeds(void) {
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
 
-  wolfSSL_CTX_set_cipher_list_IgnoreAndReturn(SSL_SUCCESS);
-
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_dtls_read);
   wolfSSL_CTX_SetIOSend_Expect(my_ctx, he_wolf_dtls_write);
@@ -451,8 +449,6 @@ void test_he_server_connect_succeeds_streaming(void) {
 
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
-
-  wolfSSL_CTX_set_cipher_list_IgnoreAndReturn(SSL_SUCCESS);
 
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_tls_read);


### PR DESCRIPTION
## Description
Reverts setting ciphers for TLS / DTLS

## Motivation and Context
We know the root cause of the issue but it requires WolfSSL to make a new release with the fix included.
As such we revert this to unblock ourselves.

## How Has This Been Tested?
This was the original behaviour and will also be tested with internal testing tools later.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`