### PR TITLE
wolfssl: patch fix for secure renegotiation bug

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -12,6 +12,7 @@ libhelium-deps:
     FROM +debian-deps
     # Copy in the build configs
     COPY *.yml .
+    COPY --dir wolfssl ./
     # Make the directory structure so that the config can be parsed
     # To improve caching we want to separate this out as the WolfSSL dependency
     # fetch and build are the slowest parts of the process.

--- a/android.yml
+++ b/android.yml
@@ -18,6 +18,8 @@
         - C_EXTRA_FLAGS= -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -fomit-frame-pointer
         - LIBS=-llog -landroid
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - autoreconf -i
         - ./configure $CROSS_OPTS C_EXTRA_FLAGS="$C_EXTRA_FLAGS" --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni
         - make

--- a/ios.yml
+++ b/ios.yml
@@ -17,6 +17,9 @@
       :environment:
         - MACOSX_DEPLOYMENT_TARGET=10.0
       :build:
+        # For some reason this attempts to run twice as a result the git apply will fail the second time
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch || true
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch || true
         - autoreconf -i
         - "cp ../../ios/autotools-ios-helper.sh ./autotools-ios-helper.sh"
         - "./autotools-ios-helper.sh"

--- a/linux.yml
+++ b/linux.yml
@@ -17,6 +17,8 @@
       :environment:
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/linux_386.yml
+++ b/linux_386.yml
@@ -18,6 +18,8 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -m32 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
         - LDFLAGS= -m32
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "autoreconf -i"
         - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -17,6 +17,8 @@
       :environment:
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "autoreconf -i"
         - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/macos.yml
+++ b/macos.yml
@@ -18,6 +18,8 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
         - CC=clang
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -19,6 +19,8 @@
         - CC=clang
         - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "autoreconf -i"
         - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -265,11 +265,6 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
     return HE_ERR_INIT_FAILED;
   }
 
-  /*
-    Commenting this out, the root cause is found out to be a WolfSSL bug.
-    TODO: To Uncomment when https://github.com/wolfSSL/wolfssl/pull/5932
-    is in a full release.
-
   // Explicitly set the cipher list
   if(ctx->connection_type == HE_CONNECTION_TYPE_STREAM) {
     res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx,
@@ -284,7 +279,6 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
   if(res != SSL_SUCCESS) {
     return HE_ERR_INIT_FAILED;
   }
-  */
 
   return he_ssl_ctx_start_common(ctx);
 }

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -426,6 +426,9 @@ void test_he_server_connect_succeeds(void) {
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
 
+  wolfSSL_CTX_set_cipher_list_ExpectAndReturn(my_ctx, "ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-"
+                                      "RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305", SSL_SUCCESS);
+
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_dtls_read);
   wolfSSL_CTX_SetIOSend_Expect(my_ctx, he_wolf_dtls_write);
@@ -449,6 +452,8 @@ void test_he_server_connect_succeeds_streaming(void) {
 
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
+
+  wolfSSL_CTX_set_cipher_list_ExpectAndReturn(my_ctx, "TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256", SSL_SUCCESS);
 
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_tls_read);

--- a/unix.yml
+++ b/unix.yml
@@ -16,6 +16,7 @@
 
 :environment:
   - :he_wolfssl_source: https://github.com/wolfSSL/wolfssl
+  # TODO: Remove wolfSSL workaround for DTLS secure renegotiation issue when new version is released
   - :he_wolfssl_commit: v5.5.4-stable
 
 :tools_test_file_preprocessor:

--- a/windows_32.yml
+++ b/windows_32.yml
@@ -52,6 +52,8 @@
         :source: https://github.com/wolfSSL/wolfssl.git
         :hash: v5.5.4-stable
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "cp ../../windows/wolfssl-user_settings-32.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-32.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/windows_32.yml
+++ b/windows_32.yml
@@ -51,6 +51,7 @@
         :method: :git
         :source: https://github.com/wolfSSL/wolfssl.git
         :hash: v5.5.4-stable
+      # TODO: Remove wolfSSL workaround for DTLS secure renegotiation issue when new version is released
       :build:
         - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
         - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -52,6 +52,8 @@
         :source: https://github.com/wolfSSL/wolfssl.git
         :hash: v5.5.4-stable
       :build:
+        - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+        - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "cp ../../windows/wolfssl-user_settings-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-64.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -51,6 +51,7 @@
         :method: :git
         :source: https://github.com/wolfSSL/wolfssl.git
         :hash: v5.5.4-stable
+      # TODO: Remove wolfSSL workaround for DTLS secure renegotiation issue when new version is released
       :build:
         - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
         - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch

--- a/wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
+++ b/wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
@@ -1,0 +1,31 @@
+From 95fde3fbb7705221e4d799c5ebeb59d7d0f2f8e9 Mon Sep 17 00:00:00 2001
+From: David Garske <david@wolfssl.com>
+Date: Thu, 22 Dec 2022 17:01:19 -0800
+Subject: [PATCH] Merge pull request #5911 from
+ julek-wolfssl/DtlsMsgPoolSend-sendSz
+
+DtlsMsgPoolSend: Use correct sendSz
+(cherry picked from commit 62e3835b0e278d245ae7fb1805f4f2b31e6dca04)
+---
+ src/internal.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/internal.c b/src/internal.c
+index c58ae3a1e..8d6fd0909 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -8857,9 +8857,8 @@ int DtlsMsgPoolSend(WOLFSSL* ssl, int sendOnlyFirstPacket)
+ #endif
+ 
+ 
+-                /* add back in header space from saved pool size */
+-                sendSz += DTLS_HANDSHAKE_EXTRA;
+-                sendSz += DTLS_RECORD_EXTRA;
++                /* add back in record header space from saved pool size */
++                sendSz += DTLS_RECORD_HEADER_SZ;
+ 
+                 if ((ret = CheckAvailableSize(ssl, sendSz)) != 0) {
+                     WOLFSSL_ERROR(ret);
+-- 
+2.39.1
+

--- a/wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
+++ b/wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
@@ -1,0 +1,2622 @@
+From 520f70c8daf6d7e1776f43b38509ca6fcebf6079 Mon Sep 17 00:00:00 2001
+From: David Garske <david@wolfssl.com>
+Date: Wed, 18 Jan 2023 15:20:21 -0800
+Subject: [PATCH] Merge pull request #5932 from julek-wolfssl/zd15346
+
+ssl->suites: use ssl->ctx->suites when possible
+
+(cherry picked from commit e1d9b37f8482a9ef198cca9fba4099bb0b15cec2)
+---
+ src/internal.c      | 582 +++++++++++++++++++++++++-------------------
+ src/ssl.c           | 183 ++++++--------
+ src/tls.c           | 125 +++++++---
+ src/tls13.c         | 119 +++++----
+ tests/api.c         |  91 +++++--
+ wolfcrypt/src/evp.c |  11 +-
+ wolfssl/internal.h  |  60 ++++-
+ wolfssl/test.h      |  94 ++++---
+ 8 files changed, 765 insertions(+), 500 deletions(-)
+
+diff --git a/src/internal.c b/src/internal.c
+index 8d6fd0909..6bc826ae8 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -2782,7 +2782,16 @@ static int GetMacDigestSize(byte macAlgo)
+ }
+ #endif /* USE_ECDSA_KEYSZ_HASH_ALGO */
+ 
+-static WC_INLINE void AddSuiteHashSigAlgo(Suites* suites, byte macAlgo,
++#define ADD_HASH_SIG_ALGO(out, inOutIdx, major, minor)  \
++    do {                                                \
++        if ((out) != NULL) {                            \
++            (out)[*(inOutIdx)    ] = (major);           \
++            (out)[*(inOutIdx) + 1] = (minor);           \
++        }                                               \
++        *(inOutIdx) += 2;                               \
++    } while (0)
++
++static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
+     byte sigAlgo, int keySz, word16* inOutIdx)
+ {
+     int addSigAlgo = 1;
+@@ -2802,59 +2811,45 @@ static WC_INLINE void AddSuiteHashSigAlgo(Suites* suites, byte macAlgo,
+     if (addSigAlgo) {
+     #ifdef HAVE_ED25519
+         if (sigAlgo == ed25519_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = ED25519_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = ED25519_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                ED25519_SA_MAJOR, ED25519_SA_MINOR);
+         }
+         else
+     #endif
+     #ifdef HAVE_ED448
+         if (sigAlgo == ed448_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = ED448_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = ED448_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                ED448_SA_MAJOR, ED448_SA_MINOR);
+         }
+         else
+     #endif
+     #ifdef HAVE_PQC
+     #ifdef HAVE_FALCON
+         if (sigAlgo == falcon_level1_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = FALCON_LEVEL1_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = FALCON_LEVEL1_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                FALCON_LEVEL1_SA_MAJOR, FALCON_LEVEL1_SA_MINOR);
+         }
+         else
+         if (sigAlgo == falcon_level5_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = FALCON_LEVEL5_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = FALCON_LEVEL5_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                FALCON_LEVEL5_SA_MAJOR, FALCON_LEVEL5_SA_MINOR);
+         }
+         else
+     #endif /* HAVE_FALCON */
+     #ifdef HAVE_DILITHIUM
+         if (sigAlgo == dilithium_level2_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = DILITHIUM_LEVEL2_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = DILITHIUM_LEVEL2_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                DILITHIUM_LEVEL2_SA_MAJOR, DILITHIUM_LEVEL2_SA_MINOR);
+         }
+         else
+         if (sigAlgo == dilithium_level3_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = DILITHIUM_LEVEL3_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = DILITHIUM_LEVEL3_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                DILITHIUM_LEVEL3_SA_MAJOR, DILITHIUM_LEVEL3_SA_MINOR);
+         }
+         else
+         if (sigAlgo == dilithium_level5_sa_algo) {
+-            suites->hashSigAlgo[*inOutIdx] = DILITHIUM_LEVEL5_SA_MAJOR;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = DILITHIUM_LEVEL5_SA_MINOR;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
++                DILITHIUM_LEVEL5_SA_MAJOR, DILITHIUM_LEVEL5_SA_MINOR);
+         }
+         else
+         if (sigAlgo == dilithium_aes_level2_sa_algo) {
+@@ -2883,32 +2878,33 @@ static WC_INLINE void AddSuiteHashSigAlgo(Suites* suites, byte macAlgo,
+ #ifdef WC_RSA_PSS
+         if (sigAlgo == rsa_pss_sa_algo) {
+             /* RSA PSS is sig then mac */
+-            suites->hashSigAlgo[*inOutIdx] = sigAlgo;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = macAlgo;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, sigAlgo, macAlgo);
+     #ifdef WOLFSSL_TLS13
+             /* Add the certificate algorithm as well */
+-            suites->hashSigAlgo[*inOutIdx] = sigAlgo;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = PSS_RSAE_TO_PSS_PSS(macAlgo);
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, sigAlgo,
++                PSS_RSAE_TO_PSS_PSS(macAlgo));
+     #endif
+         }
+         else
+ #endif
+         {
+-            suites->hashSigAlgo[*inOutIdx] = macAlgo;
+-            *inOutIdx += 1;
+-            suites->hashSigAlgo[*inOutIdx] = sigAlgo;
+-            *inOutIdx += 1;
++            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, macAlgo, sigAlgo);
+         }
+     }
+ }
+ 
+ void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig, int haveRSAsig,
+-                           int haveFalconSig, int haveDilithiumSig,
+-                           int haveAnon, int tls1_2, int keySz)
++    int haveFalconSig, int haveDilithiumSig, int haveAnon, int tls1_2,
++    int keySz)
++{
++    InitSuitesHashSigAlgo_ex(suites->hashSigAlgo, haveECDSAsig, haveRSAsig,
++            haveFalconSig, haveDilithiumSig, haveAnon, tls1_2, keySz,
++            &suites->hashSigAlgoSz);
++}
++
++void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig,
++    int haveRSAsig, int haveFalconSig, int haveDilithiumSig, int haveAnon,
++    int tls1_2, int keySz, word16* len)
+ {
+     word16 idx = 0;
+ 
+@@ -2919,50 +2915,49 @@ void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig, int haveRSAsig,
+     if (haveECDSAsig) {
+ #ifdef HAVE_ECC
+     #ifdef WOLFSSL_SHA512
+-        AddSuiteHashSigAlgo(suites, sha512_mac, ecc_dsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha512_mac, ecc_dsa_sa_algo, keySz,
++            &idx);
+     #endif
+     #ifdef WOLFSSL_SHA384
+-        AddSuiteHashSigAlgo(suites, sha384_mac, ecc_dsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha384_mac, ecc_dsa_sa_algo, keySz,
++            &idx);
+     #endif
+     #ifndef NO_SHA256
+-        AddSuiteHashSigAlgo(suites, sha256_mac, ecc_dsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha256_mac, ecc_dsa_sa_algo, keySz,
++            &idx);
+     #endif
+     #if !defined(NO_SHA) && (!defined(NO_OLD_TLS) || \
+                                             defined(WOLFSSL_ALLOW_TLS_SHA1))
+-        AddSuiteHashSigAlgo(suites, sha_mac, ecc_dsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha_mac, ecc_dsa_sa_algo, keySz, &idx);
+     #endif
+ #endif
+     #ifdef HAVE_ED25519
+-        AddSuiteHashSigAlgo(suites, no_mac, ed25519_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, ed25519_sa_algo, keySz, &idx);
+     #endif
+     #ifdef HAVE_ED448
+-        AddSuiteHashSigAlgo(suites, no_mac, ed448_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, ed448_sa_algo, keySz, &idx);
+     #endif
+     }
+ #endif /* HAVE_ECC || HAVE_ED25519 || HAVE_ED448 */
+     if (haveFalconSig) {
+ #if defined(HAVE_PQC)
+ #ifdef HAVE_FALCON
+-        AddSuiteHashSigAlgo(suites, no_mac, falcon_level1_sa_algo, keySz, &idx);
+-        AddSuiteHashSigAlgo(suites, no_mac, falcon_level5_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level1_sa_algo, keySz,
++            &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level5_sa_algo, keySz,
++            &idx);
+ #endif /* HAVE_FALCON */
+ #endif /* HAVE_PQC */
+     }
+     if (haveDilithiumSig) {
+ #if defined(HAVE_PQC)
+ #ifdef HAVE_DILITHIUM
+-        AddSuiteHashSigAlgo(suites, no_mac, dilithium_level2_sa_algo, keySz,
+-                            &idx);
+-        AddSuiteHashSigAlgo(suites, no_mac, dilithium_level3_sa_algo, keySz,
+-                            &idx);
+-        AddSuiteHashSigAlgo(suites, no_mac, dilithium_level5_sa_algo, keySz,
+-                            &idx);
+-        AddSuiteHashSigAlgo(suites, no_mac, dilithium_aes_level2_sa_algo, keySz,
+-                            &idx);
+-        AddSuiteHashSigAlgo(suites, no_mac, dilithium_aes_level3_sa_algo, keySz,
+-                            &idx);
+-        AddSuiteHashSigAlgo(suites, no_mac, dilithium_aes_level5_sa_algo, keySz,
+-                            &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level2_sa_algo,
++            keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level3_sa_algo,
++            keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level5_sa_algo,
++            keySz, &idx);
+ #endif /* HAVE_DILITHIUM */
+ #endif /* HAVE_PQC */
+     }
+@@ -2970,46 +2965,79 @@ void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig, int haveRSAsig,
+     #ifdef WC_RSA_PSS
+         if (tls1_2) {
+         #ifdef WOLFSSL_SHA512
+-            AddSuiteHashSigAlgo(suites, sha512_mac, rsa_pss_sa_algo, keySz,
+-                                                                          &idx);
++            AddSuiteHashSigAlgo(hashSigAlgo, sha512_mac, rsa_pss_sa_algo, keySz,
++                &idx);
+         #endif
+         #ifdef WOLFSSL_SHA384
+-            AddSuiteHashSigAlgo(suites, sha384_mac, rsa_pss_sa_algo, keySz,
+-                                                                          &idx);
++            AddSuiteHashSigAlgo(hashSigAlgo, sha384_mac, rsa_pss_sa_algo, keySz,
++                &idx);
+         #endif
+         #ifndef NO_SHA256
+-            AddSuiteHashSigAlgo(suites, sha256_mac, rsa_pss_sa_algo, keySz,
+-                                                                          &idx);
++            AddSuiteHashSigAlgo(hashSigAlgo, sha256_mac, rsa_pss_sa_algo, keySz,
++                &idx);
+         #endif
+         }
+     #endif
+     #ifdef WOLFSSL_SHA512
+-        AddSuiteHashSigAlgo(suites, sha512_mac, rsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha512_mac, rsa_sa_algo, keySz, &idx);
+     #endif
+     #ifdef WOLFSSL_SHA384
+-        AddSuiteHashSigAlgo(suites, sha384_mac, rsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha384_mac, rsa_sa_algo, keySz, &idx);
+     #endif
+     #ifndef NO_SHA256
+-        AddSuiteHashSigAlgo(suites, sha256_mac, rsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha256_mac, rsa_sa_algo, keySz, &idx);
+     #endif
+     #ifdef WOLFSSL_SHA224
+-        AddSuiteHashSigAlgo(suites, sha224_mac, rsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha224_mac, rsa_sa_algo, keySz, &idx);
+     #endif
+     #if !defined(NO_SHA) && (!defined(NO_OLD_TLS) || \
+                                             defined(WOLFSSL_ALLOW_TLS_SHA1))
+-        AddSuiteHashSigAlgo(suites, sha_mac, rsa_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha_mac, rsa_sa_algo, keySz, &idx);
+     #endif
+     }
+ 
+ #ifdef HAVE_ANON
+     if (haveAnon) {
+-        AddSuiteHashSigAlgo(suites, sha_mac, anonymous_sa_algo, keySz, &idx);
++        AddSuiteHashSigAlgo(hashSigAlgo, sha_mac, anonymous_sa_algo, keySz,
++            &idx);
+     }
+ #endif
+ 
+     (void)haveAnon;
+     (void)haveECDSAsig;
+-    suites->hashSigAlgoSz = idx;
++    *len = idx;
++}
++
++int AllocateCtxSuites(WOLFSSL_CTX* ctx)
++{
++    if (ctx->suites == NULL) {
++        ctx->suites = (Suites*)XMALLOC(sizeof(Suites), ctx->heap,
++                                       DYNAMIC_TYPE_SUITES);
++        if (ctx->suites == NULL) {
++            WOLFSSL_MSG("Memory alloc for Suites failed");
++            return MEMORY_ERROR;
++        }
++        XMEMSET(ctx->suites, 0, sizeof(Suites));
++    }
++    return 0;
++}
++
++/* Call this when the ssl object needs to have its own ssl->suites object */
++int AllocateSuites(WOLFSSL* ssl)
++{
++    if (ssl->suites == NULL) {
++        ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
++                                       DYNAMIC_TYPE_SUITES);
++        if (ssl->suites == NULL) {
++            WOLFSSL_MSG("Suites Memory error");
++            return MEMORY_ERROR;
++        }
++        if (ssl->ctx != NULL && ssl->ctx->suites != NULL)
++            XMEMCPY(ssl->suites, ssl->ctx->suites, sizeof(Suites));
++        else
++            XMEMSET(ssl->suites, 0, sizeof(Suites));
++    }
++    return 0;
+ }
+ 
+ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
+@@ -5989,6 +6017,48 @@ int wolfSSL_CTX_IsPrivatePkSet(WOLFSSL_CTX* ctx)
+ }
+ #endif /* HAVE_PK_CALLBACKS */
+ 
++static void InitSuites_EitherSide(Suites* suites, ProtocolVersion pv, int keySz,
++        word16 haveRSA, word16 havePSK, word16 haveDH, word16 haveECDSAsig,
++        word16 haveECC, word16 haveStaticECC,
++        word16 haveFalconSig, word16 haveDilithiumSig, word16 haveAnon,
++        int side)
++{
++    /* make sure server has DH parms, and add PSK if there */
++    if (side == WOLFSSL_SERVER_END) {
++        InitSuites(suites, pv, keySz, haveRSA, havePSK, haveDH, haveECDSAsig,
++                   haveECC, TRUE, haveStaticECC, haveFalconSig,
++                   haveDilithiumSig, haveAnon, TRUE, side);
++    }
++    else {
++        InitSuites(suites, pv, keySz, haveRSA, havePSK, TRUE, haveECDSAsig,
++                   haveECC, TRUE, haveStaticECC, haveFalconSig,
++                   haveDilithiumSig, haveAnon, TRUE, side);
++    }
++}
++
++void InitSSL_CTX_Suites(WOLFSSL_CTX* ctx)
++{
++    int keySz = 0;
++    byte havePSK = 0;
++    byte haveAnon = 0;
++    byte haveRSA = 0;
++#ifndef NO_RSA
++    haveRSA = 1;
++#endif
++#ifndef NO_PSK
++    havePSK = ctx->havePSK;
++#endif /* NO_PSK */
++#ifdef HAVE_ANON
++    haveAnon = ctx->haveAnon;
++#endif /* HAVE_ANON*/
++#ifndef NO_CERTS
++    keySz = ctx->privateKeySz;
++#endif
++    InitSuites_EitherSide(ctx->suites, ctx->method->version, keySz,
++            haveRSA, havePSK, ctx->haveDH, ctx->haveECDSAsig, ctx->haveECC,
++            ctx->haveStaticECC, ctx->haveFalconSig, ctx->haveDilithiumSig,
++            haveAnon, ctx->method->side);
++}
+ 
+ int InitSSL_Suites(WOLFSSL* ssl)
+ {
+@@ -6035,20 +6105,12 @@ int InitSSL_Suites(WOLFSSL* ssl)
+     keySz = ssl->buffers.keySz;
+ #endif
+ 
+-    /* make sure server has DH parms, and add PSK if there */
+-    if (ssl->options.side == WOLFSSL_SERVER_END) {
+-        InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+-                   ssl->options.haveDH, ssl->options.haveECDSAsig,
+-                   ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+-                   ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
+-                   ssl->options.haveAnon, TRUE, ssl->options.side);
+-    }
+-    else {
+-        InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK, TRUE,
+-                   ssl->options.haveECDSAsig, ssl->options.haveECC, TRUE,
+-                   ssl->options.haveStaticECC, ssl->options.haveFalconSig,
+-                   ssl->options.haveDilithiumSig, ssl->options.haveAnon, TRUE,
+-                   ssl->options.side);
++    if (ssl->suites != NULL) {
++        InitSuites_EitherSide(ssl->suites, ssl->version, keySz, haveRSA,
++                havePSK, ssl->options.haveDH, ssl->options.haveECDSAsig,
++                ssl->options.haveECC, ssl->options.haveStaticECC,
++                ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
++                ssl->options.haveAnon, ssl->options.side);
+     }
+ 
+ #if !defined(NO_CERTS) && !defined(WOLFSSL_SESSION_EXPORT)
+@@ -6134,11 +6196,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
+     if (!ssl || !ctx)
+         return BAD_FUNC_ARG;
+ 
+-#ifndef SINGLE_THREADED
+-    if (ssl->suites == NULL && !writeDup)
+-        return BAD_FUNC_ARG;
+-#endif
+-
+     newSSL = ssl->ctx == NULL; /* Assign after null check */
+ 
+ #ifndef NO_PSK
+@@ -6367,15 +6424,11 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
+         }
+ #endif /* NO_PSK */
+ 
+-        if (ctx->suites) {
+-#ifndef SINGLE_THREADED
+-            *ssl->suites = *ctx->suites;
+-#else
+-            ssl->suites = ctx->suites;
+-#endif
+-        }
+-        else {
+-            XMEMSET(ssl->suites, 0, sizeof(Suites));
++        if (ssl->suites != NULL) {
++            if (ctx->suites == NULL)
++                XMEMSET(ssl->suites, 0, sizeof(Suites));
++            else
++                XMEMCPY(ssl->suites, ctx->suites, sizeof(Suites));
+         }
+ 
+         if (ssl->options.side != WOLFSSL_NEITHER_END) {
+@@ -6908,28 +6961,15 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
+         XMEMSET(ssl->param, 0, sizeof(WOLFSSL_X509_VERIFY_PARAM));
+ #endif
+ 
+-#ifdef SINGLE_THREADED
+-        if (ctx->suites == NULL)
+-#endif
+-        {
++        if (ctx->suites == NULL) {
+             /* suites */
+-            ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-            if (ssl->suites == NULL) {
+-                WOLFSSL_MSG("Suites Memory error");
+-                return MEMORY_E;
+-            }
+-        #ifdef OPENSSL_ALL
+-            ssl->suites->stack = NULL;
+-        #endif
+-#ifdef SINGLE_THREADED
+-            ssl->options.ownSuites = 1;
+-#endif
+-        }
+-#ifdef SINGLE_THREADED
+-        else {
+-            ssl->options.ownSuites = 0;
++            ret = AllocateCtxSuites(ctx);
++            if (ret != 0)
++                return ret;
++            InitSSL_CTX_Suites(ctx);
+         }
++#ifdef OPENSSL_ALL
++        ssl->suitesStack = NULL;
+ #endif
+     } /* !writeDup */
+ 
+@@ -7442,19 +7482,15 @@ void FreeKeyExchange(WOLFSSL* ssl)
+ /* Free up all memory used by Suites structure from WOLFSSL */
+ void FreeSuites(WOLFSSL* ssl)
+ {
+-#ifdef SINGLE_THREADED
+-    if (ssl->options.ownSuites)
+-#endif
+-    {
+-    #ifdef OPENSSL_ALL
+-        if (ssl->suites != NULL) {
+-            /* Enough to free stack structure since WOLFSSL_CIPHER
+-             * isn't allocated separately. */
+-            wolfSSL_sk_SSL_CIPHER_free(ssl->suites->stack);
+-        }
+-    #endif
+-        XFREE(ssl->suites, ssl->heap, DYNAMIC_TYPE_SUITES);
++#ifdef OPENSSL_ALL
++    if (ssl->suitesStack != NULL) {
++        /* Enough to free stack structure since WOLFSSL_CIPHER
++         * isn't allocated separately. */
++        wolfSSL_sk_SSL_CIPHER_free(ssl->suitesStack);
++        ssl->suitesStack = NULL;
+     }
++#endif
++    XFREE(ssl->suites, ssl->heap, DYNAMIC_TYPE_SUITES);
+     ssl->suites = NULL;
+ }
+ 
+@@ -8262,6 +8298,7 @@ static DtlsFragBucket* DtlsMsgCreateFragBucket(word32 offset, const byte* data,
+         if (data != NULL)
+             XMEMCPY(bucket->buf, data, dataSz);
+     }
++    (void)heap;
+     return bucket;
+ }
+ 
+@@ -21612,6 +21649,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
+ #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)
+     WOLF_STACK_OF(WOLFSSL_X509_NAME)* names;
+ #endif
++    const Suites* suites = WOLFSSL_SUITES(ssl);
+ 
+     int  typeTotal = 1;  /* only 1 for now */
+     int  reqSz = ENUM_LEN + typeTotal + REQ_HEADER_SZ;  /* add auth later */
+@@ -21620,7 +21658,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
+     WOLFSSL_ENTER("SendCertificateRequest");
+ 
+     if (IsAtLeastTLSv1_2(ssl))
+-        reqSz += LENGTH_SZ + ssl->suites->hashSigAlgoSz;
++        reqSz += LENGTH_SZ + suites->hashSigAlgoSz;
+ 
+ #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)
+     /* Certificate Authorities */
+@@ -21687,12 +21725,11 @@ int SendCertificateRequest(WOLFSSL* ssl)
+ 
+     /* supported hash/sig */
+     if (IsAtLeastTLSv1_2(ssl)) {
+-        c16toa(ssl->suites->hashSigAlgoSz, &output[i]);
++        c16toa(suites->hashSigAlgoSz, &output[i]);
+         i += OPAQUE16_LEN;
+ 
+-        XMEMCPY(&output[i],
+-                         ssl->suites->hashSigAlgo, ssl->suites->hashSigAlgoSz);
+-        i += ssl->suites->hashSigAlgoSz;
++        XMEMCPY(&output[i], suites->hashSigAlgo, suites->hashSigAlgoSz);
++        i += suites->hashSigAlgoSz;
+     }
+ 
+     /* Certificate Authorities */
+@@ -24313,8 +24350,18 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
+     }
+ 
+     if (next[0] == 0 || XSTRCMP(next, "ALL") == 0 ||
+-        XSTRCMP(next, "DEFAULT") == 0 || XSTRCMP(next, "HIGH") == 0)
++        XSTRCMP(next, "DEFAULT") == 0 || XSTRCMP(next, "HIGH") == 0) {
++        /* Add all ciphersuites except anonymous and null ciphers */
++        InitSuites(suites, ctx->method->version,
++#ifndef NO_CERTS
++                ctx->privateKeySz,
++#else
++                0,
++#endif
++                1, 1, 1, 1,
++                   1, 1, 1, 1, 1, 0, 0, ctx->method->side);
+         return 1; /* wolfSSL default */
++    }
+ 
+     do {
+         const char* current = next;
+@@ -24728,8 +24775,9 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
+         keySz = ctx->privateKeySz;
+     #endif
+         suites->suiteSz = (word16)idx;
+-        InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig, haveFalconSig,
+-                              haveDilithiumSig, haveAnon, 1, keySz);
++        InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig,
++                              haveFalconSig, haveDilithiumSig, haveAnon, 1,
++                              keySz);
+         suites->setSuites = 1;
+     }
+ 
+@@ -24874,7 +24922,7 @@ int SetSuitesHashSigAlgo(Suites* suites, const char* list)
+                     break;
+                 }
+             }
+-            AddSuiteHashSigAlgo(suites, mac_alg, sig_alg, 0, &idx);
++            AddSuiteHashSigAlgo(suites->hashSigAlgo, mac_alg, sig_alg, 0, &idx);
+             sig_alg = 0;
+             mac_alg = no_mac;
+             s = list + 1;
+@@ -24953,7 +25001,7 @@ static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
+ #endif /* HAVE_PQC */
+ #ifdef WC_RSA_PSS
+     /* RSA certificate and PSS sig alg. */
+-    if (ssl->suites->sigAlgo == rsa_sa_algo) {
++    if (ssl->options.sigAlgo == rsa_sa_algo) {
+     #if defined(WOLFSSL_TLS13)
+         /* TLS 1.3 only supports RSA-PSS. */
+         if (IsAtLeastTLSv1_3(ssl->version))
+@@ -24965,7 +25013,7 @@ static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
+     }
+ #endif
+     /* Signature algorithm matches certificate. */
+-    return sigAlgo == ssl->suites->sigAlgo;
++    return sigAlgo == ssl->options.sigAlgo;
+ }
+ 
+ #if defined(HAVE_ECC) && defined(WOLFSSL_TLS13) || \
+@@ -25007,18 +25055,18 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+         /* TLS 1.3 cipher suites don't have public key algorithms in them.
+          * Using the one in the certificate - if any.
+          */
+-        ssl->suites->sigAlgo = ssl->buffers.keyType;
++        ssl->options.sigAlgo = ssl->buffers.keyType;
+     #endif
+     }
+     else {
+-        ssl->suites->sigAlgo = ssl->specs.sig_algo;
++        ssl->options.sigAlgo = ssl->specs.sig_algo;
+     }
+-    if (ssl->suites->sigAlgo == anonymous_sa_algo) {
++    if (ssl->options.sigAlgo == anonymous_sa_algo) {
+         /* PSK ciphersuite - get digest to use from cipher suite */
+-        ssl->suites->hashAlgo = ssl->specs.mac_algorithm;
++        ssl->options.hashAlgo = ssl->specs.mac_algorithm;
+         return 0;
+     }
+-    ssl->suites->hashAlgo = minHash = MinHashAlgo(ssl);
++    ssl->options.hashAlgo = minHash = MinHashAlgo(ssl);
+ 
+     /* No list means go with the defaults. */
+     if (hashSigAlgoSz == 0)
+@@ -25039,8 +25087,8 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+     #ifdef HAVE_ED25519
+         if (ssl->pkCurveOID == ECC_ED25519_OID) {
+             /* Matched Ed25519 - set chosen and finished. */
+-            ssl->suites->sigAlgo = sigAlgo;
+-            ssl->suites->hashAlgo = hashAlgo;
++            ssl->options.sigAlgo = sigAlgo;
++            ssl->options.hashAlgo = hashAlgo;
+             ret = 0;
+             break;
+         }
+@@ -25048,8 +25096,8 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+     #ifdef HAVE_ED448
+         if (ssl->pkCurveOID == ECC_ED448_OID) {
+             /* Matched Ed448 - set chosen and finished. */
+-            ssl->suites->sigAlgo = sigAlgo;
+-            ssl->suites->hashAlgo = hashAlgo;
++            ssl->options.sigAlgo = sigAlgo;
++            ssl->options.hashAlgo = hashAlgo;
+             ret = 0;
+             break;
+         }
+@@ -25059,8 +25107,8 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+         if (ssl->pkCurveOID == CTC_FALCON_LEVEL1 ||
+             ssl->pkCurveOID == CTC_FALCON_LEVEL5 ) {
+             /* Matched Falcon - set chosen and finished. */
+-            ssl->suites->sigAlgo = sigAlgo;
+-            ssl->suites->hashAlgo = hashAlgo;
++            ssl->options.sigAlgo = sigAlgo;
++            ssl->options.hashAlgo = hashAlgo;
+             ret = 0;
+             break;
+         }
+@@ -25073,8 +25121,8 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+             ssl->pkCurveOID == CTC_DILITHIUM_AES_LEVEL3 ||
+             ssl->pkCurveOID == CTC_DILITHIUM_AES_LEVEL5 ) {
+             /* Matched Dilithium - set chosen and finished. */
+-            ssl->suites->sigAlgo = sigAlgo;
+-            ssl->suites->hashAlgo = hashAlgo;
++            ssl->options.sigAlgo = sigAlgo;
++            ssl->options.hashAlgo = hashAlgo;
+             ret = 0;
+             break;
+         }
+@@ -25098,8 +25146,8 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+                 continue;
+ 
+             /* Matched ECDSA exaclty - set chosen and finished. */
+-            ssl->suites->hashAlgo = hashAlgo;
+-            ssl->suites->sigAlgo = sigAlgo;
++            ssl->options.hashAlgo = hashAlgo;
++            ssl->options.sigAlgo = sigAlgo;
+             ret = 0;
+             break;
+         }
+@@ -25119,9 +25167,9 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+                 continue;
+ 
+             /* Looking for exact match or next highest. */
+-            if (ret != 0 || hashAlgo <= ssl->suites->hashAlgo) {
+-                ssl->suites->hashAlgo = hashAlgo;
+-                ssl->suites->sigAlgo = sigAlgo;
++            if (ret != 0 || hashAlgo <= ssl->options.hashAlgo) {
++                ssl->options.hashAlgo = hashAlgo;
++                ssl->options.sigAlgo = sigAlgo;
+             #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
+                 ssl->namedGroup = 0;
+             #endif
+@@ -25154,16 +25202,16 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+         #endif
+             #ifdef WOLFSSL_STRONGEST_HASH_SIG
+                 /* Is hash algorithm weaker than chosen/min? */
+-                if (hashAlgo < ssl->suites->hashAlgo)
++                if (hashAlgo < ssl->options.hashAlgo)
+                     break;
+             #else
+                 /* Is hash algorithm stonger than last chosen? */
+-                if (ret == 0 && hashAlgo > ssl->suites->hashAlgo)
++                if (ret == 0 && hashAlgo > ssl->options.hashAlgo)
+                     break;
+             #endif
+                 /* The chosen one - but keep looking. */
+-                ssl->suites->hashAlgo = hashAlgo;
+-                ssl->suites->sigAlgo = sigAlgo;
++                ssl->options.hashAlgo = hashAlgo;
++                ssl->options.sigAlgo = sigAlgo;
+                 ret = 0;
+                 break;
+             default:
+@@ -26036,6 +26084,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+         int                idSz;
+         int                ret;
+         word16             extSz = 0;
++        const Suites*      suites;
+ 
+         if (ssl == NULL) {
+             return BAD_FUNC_ARG;
+@@ -26051,7 +26100,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+         WOLFSSL_START(WC_FUNC_CLIENT_HELLO_SEND);
+         WOLFSSL_ENTER("SendClientHello");
+ 
+-        if (ssl->suites == NULL) {
++        suites = WOLFSSL_SUITES(ssl);
++
++        if (suites == NULL) {
+             WOLFSSL_MSG("Bad suites pointer in SendClientHello");
+             return SUITES_ERROR;
+         }
+@@ -26075,8 +26126,14 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+ #endif
+         length = VERSION_SZ + RAN_LEN
+                + idSz + ENUM_LEN
+-               + ssl->suites->suiteSz + SUITE_LEN
++               + SUITE_LEN
+                + COMP_LEN + ENUM_LEN;
++#ifndef NO_FORCE_SCR_SAME_SUITE
++        if (IsSCR(ssl))
++            length += SUITE_LEN;
++        else
++#endif
++            length += suites->suiteSz;
+ 
+ #ifdef HAVE_TLS_EXTENSIONS
+         /* auto populate extensions supported unless user defined */
+@@ -26088,9 +26145,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+             return ret;
+         length += extSz;
+ #else
+-        if (IsAtLeastTLSv1_2(ssl) && ssl->suites->hashSigAlgoSz)
++        if (IsAtLeastTLSv1_2(ssl) && suites->hashSigAlgoSz)
+             extSz += HELLO_EXT_SZ + HELLO_EXT_SIGALGO_SZ
+-                   + ssl->suites->hashSigAlgoSz;
++                   + suites->hashSigAlgoSz;
+ #ifdef HAVE_EXTENDED_MASTER
+         if (ssl->options.haveEMS)
+             extSz += HELLO_EXT_SZ;
+@@ -26171,11 +26228,23 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+             }
+         }
+ #endif
+-        /* then cipher suites */
+-        c16toa(ssl->suites->suiteSz, output + idx);
+-        idx += OPAQUE16_LEN;
+-        XMEMCPY(output + idx, &ssl->suites->suites, ssl->suites->suiteSz);
+-        idx += ssl->suites->suiteSz;
++
++#ifndef NO_FORCE_SCR_SAME_SUITE
++        if (IsSCR(ssl)) {
++            c16toa(SUITE_LEN, output + idx);
++            idx += OPAQUE16_LEN;
++            output[idx++] = ssl->options.cipherSuite0;
++            output[idx++] = ssl->options.cipherSuite;
++        }
++        else
++#endif
++        {
++            /* then cipher suites */
++            c16toa(suites->suiteSz, output + idx);
++            idx += OPAQUE16_LEN;
++            XMEMCPY(output + idx, &suites->suites, suites->suiteSz);
++            idx += suites->suiteSz;
++        }
+ 
+         /* last, compression */
+         output[idx++] = COMP_LEN;
+@@ -26198,20 +26267,20 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+             idx += HELLO_EXT_SZ_SZ;
+ 
+             if (IsAtLeastTLSv1_2(ssl)) {
+-                if (ssl->suites->hashSigAlgoSz) {
++                if (suites->hashSigAlgoSz) {
+                     word16 i;
+                     /* extension type */
+                     c16toa(HELLO_EXT_SIG_ALGO, output + idx);
+                     idx += HELLO_EXT_TYPE_SZ;
+                     /* extension data length */
+-                    c16toa(HELLO_EXT_SIGALGO_SZ + ssl->suites->hashSigAlgoSz,
++                    c16toa(HELLO_EXT_SIGALGO_SZ + suites->hashSigAlgoSz,
+                            output + idx);
+                     idx += HELLO_EXT_SZ_SZ;
+                     /* sig algos length */
+-                    c16toa(ssl->suites->hashSigAlgoSz, output + idx);
++                    c16toa(suites->hashSigAlgoSz, output + idx);
+                     idx += HELLO_EXT_SIGALGO_SZ;
+-                    for (i=0; i < ssl->suites->hashSigAlgoSz; i++, idx++) {
+-                        output[idx] = ssl->suites->hashSigAlgo[i];
++                    for (i=0; i < suites->hashSigAlgoSz; i++, idx++) {
++                        output[idx] = suites->hashSigAlgo[i];
+                     }
+                 }
+             }
+@@ -26605,9 +26674,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+         cs0 = input[i++];
+         cs1 = input[i++];
+ 
+-#ifdef HAVE_SECURE_RENEGOTIATION
+-        if (ssl->secure_renegotiation && ssl->secure_renegotiation->enabled &&
+-                                         ssl->options.handShakeDone) {
++#ifndef WOLFSSL_NO_STRICT_CIPHER_SUITE
++#if defined(HAVE_SECURE_RENEGOTIATION) && !defined(NO_FORCE_SCR_SAME_SUITE)
++        if (IsSCR(ssl)) {
+             if (ssl->options.cipherSuite0 != cs0 ||
+                 ssl->options.cipherSuite  != cs1) {
+                 WOLFSSL_MSG("Server changed cipher suite during scr");
+@@ -26615,25 +26684,15 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+                 return MATCH_SUITE_ERROR;
+             }
+         }
++        else
+ #endif
+-
+-        ssl->options.cipherSuite0 = cs0;
+-        ssl->options.cipherSuite  = cs1;
+-    #ifdef WOLFSSL_DEBUG_TLS
+-        WOLFSSL_MSG("Chosen cipher suite:");
+-        WOLFSSL_MSG(GetCipherNameInternal(ssl->options.cipherSuite0,
+-                                          ssl->options.cipherSuite));
+-    #endif
+-
+-        compression = input[i++];
+-
+-#ifndef WOLFSSL_NO_STRICT_CIPHER_SUITE
+         {
+             word32 idx, found = 0;
++            const Suites* suites = WOLFSSL_SUITES(ssl);
+             /* confirm server_hello cipher suite is one sent in client_hello */
+-            for (idx = 0; idx < ssl->suites->suiteSz; idx += 2) {
+-                if (ssl->suites->suites[idx]   == cs0 &&
+-                    ssl->suites->suites[idx+1] == cs1) {
++            for (idx = 0; idx < suites->suiteSz; idx += 2) {
++                if (suites->suites[idx]   == cs0 &&
++                    suites->suites[idx+1] == cs1) {
+                     found = 1;
+                     break;
+                 }
+@@ -26646,6 +26705,16 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+         }
+ #endif /* !WOLFSSL_NO_STRICT_CIPHER_SUITE */
+ 
++        ssl->options.cipherSuite0 = cs0;
++        ssl->options.cipherSuite  = cs1;
++    #ifdef WOLFSSL_DEBUG_TLS
++        WOLFSSL_MSG("Chosen cipher suite:");
++        WOLFSSL_MSG(GetCipherNameInternal(ssl->options.cipherSuite0,
++                                          ssl->options.cipherSuite));
++    #endif
++
++        compression = input[i++];
++
+         if (compression != NO_COMPRESSION && !ssl->options.usingCompression) {
+             WOLFSSL_MSG("Server forcing compression w/o support");
+             WOLFSSL_ERROR_VERBOSE(COMPRESSION_ERROR);
+@@ -26952,8 +27021,8 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+             *inOutIdx += len;
+     #ifdef WC_RSA_PSS
+             ssl->pssAlgo = 0;
+-            if (ssl->suites->sigAlgo == rsa_pss_sa_algo)
+-                ssl->pssAlgo |= 1 << ssl->suites->hashAlgo;
++            if (ssl->options.sigAlgo == rsa_pss_sa_algo)
++                ssl->pssAlgo |= 1 << ssl->options.hashAlgo;
+     #endif
+         }
+ 
+@@ -29929,7 +29998,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
+             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
+         #ifdef WC_RSA_PSS
+                 if (IsAtLeastTLSv1_2(ssl) &&
+-                                (ssl->pssAlgo & (1 << ssl->suites->hashAlgo))) {
++                                (ssl->pssAlgo & (1 << ssl->options.hashAlgo))) {
+                     args->sigAlgo = rsa_pss_sa_algo;
+                 }
+                 else
+@@ -29944,10 +30013,10 @@ int SendCertificateVerify(WOLFSSL* ssl)
+                 args->sigAlgo = ed448_sa_algo;
+ 
+             if (IsAtLeastTLSv1_2(ssl)) {
+-                EncodeSigAlg(ssl->suites->hashAlgo, args->sigAlgo,
++                EncodeSigAlg(ssl->options.hashAlgo, args->sigAlgo,
+                              args->verify);
+                 args->extraSz = HASH_SIG_SIZE;
+-                SetDigest(ssl, ssl->suites->hashAlgo);
++                SetDigest(ssl, ssl->options.hashAlgo);
+             }
+         #ifndef NO_OLD_TLS
+             else {
+@@ -29967,7 +30036,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
+                     ssl->buffers.sig.length = wc_EncodeSignature(
+                             ssl->buffers.sig.buffer, ssl->buffers.digest.buffer,
+                             ssl->buffers.digest.length,
+-                            TypeHash(ssl->suites->hashAlgo));
++                            TypeHash(ssl->options.hashAlgo));
+                 }
+ 
+                 /* prepend hdr */
+@@ -30066,7 +30135,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
+                 ret = RsaSign(ssl,
+                     ssl->buffers.sig.buffer, ssl->buffers.sig.length,
+                     args->verify + args->extraSz + VERIFY_HEADER, &args->sigSz,
+-                    args->sigAlgo, ssl->suites->hashAlgo, key,
++                    args->sigAlgo, ssl->options.hashAlgo, key,
+                     ssl->buffers.key
+                 );
+             }
+@@ -30147,7 +30216,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
+                     ret = VerifyRsaSign(ssl,
+                         args->verifySig, args->sigSz,
+                         ssl->buffers.sig.buffer, ssl->buffers.sig.length,
+-                        args->sigAlgo, ssl->suites->hashAlgo, key,
++                        args->sigAlgo, ssl->options.hashAlgo, key,
+                         ssl->buffers.key
+                     );
+ 
+@@ -31486,7 +31555,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                 ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
+                         }
+                         else {
+-                            switch(ssl->suites->sigAlgo) {
++                            switch(ssl->options.sigAlgo) {
+                         #ifndef NO_RSA
+                         #ifdef WC_RSA_PSS
+                             case rsa_pss_sa_algo:
+@@ -31613,12 +31682,12 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ 
+                         /* Determine hash type */
+                         if (IsAtLeastTLSv1_2(ssl)) {
+-                            EncodeSigAlg(ssl->suites->hashAlgo,
+-                                         ssl->suites->sigAlgo,
++                            EncodeSigAlg(ssl->options.hashAlgo,
++                                         ssl->options.sigAlgo,
+                                          &args->output[args->idx]);
+                             args->idx += 2;
+ 
+-                            hashType = HashAlgoToType(ssl->suites->hashAlgo);
++                            hashType = HashAlgoToType(ssl->options.hashAlgo);
+                             if (hashType == WC_HASH_TYPE_NONE) {
+                                 ERROR_OUT(ALGO_ID_E, exit_sske);
+                             }
+@@ -31627,7 +31696,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                             /* only using sha and md5 for rsa */
+                         #ifndef NO_OLD_TLS
+                             hashType = WC_HASH_TYPE_SHA;
+-                            if (ssl->suites->sigAlgo == rsa_sa_algo) {
++                            if (ssl->options.sigAlgo == rsa_sa_algo) {
+                                 hashType = WC_HASH_TYPE_MD5_SHA;
+                             }
+                         #else
+@@ -31646,7 +31715,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ 
+                         ret = HashSkeData(ssl, hashType,
+                             args->output + preSigIdx, preSigSz,
+-                            ssl->suites->sigAlgo);
++                            ssl->options.sigAlgo);
+                         if (ret != 0) {
+                             goto exit_sske;
+                         }
+@@ -31654,7 +31723,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                         args->sigSz = args->tmpSigSz;
+ 
+                         /* Sign hash to create signature */
+-                        switch (ssl->suites->sigAlgo)
++                        switch (ssl->options.sigAlgo)
+                         {
+                         #ifndef NO_RSA
+                             case rsa_sa_algo:
+@@ -31672,7 +31741,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                         wc_EncodeSignature(encodedSig,
+                                             ssl->buffers.digest.buffer,
+                                             ssl->buffers.digest.length,
+-                                            TypeHash(ssl->suites->hashAlgo));
++                                            TypeHash(ssl->options.hashAlgo));
+ 
+                                     /* Replace sig buffer with new one */
+                                     XFREE(ssl->buffers.digest.buffer, ssl->heap,
+@@ -31837,12 +31906,12 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ 
+                         /* Determine hash type */
+                         if (IsAtLeastTLSv1_2(ssl)) {
+-                            EncodeSigAlg(ssl->suites->hashAlgo,
+-                                         ssl->suites->sigAlgo,
++                            EncodeSigAlg(ssl->options.hashAlgo,
++                                         ssl->options.sigAlgo,
+                                          &args->output[args->idx]);
+                             args->idx += 2;
+ 
+-                            hashType = HashAlgoToType(ssl->suites->hashAlgo);
++                            hashType = HashAlgoToType(ssl->options.hashAlgo);
+                             if (hashType == WC_HASH_TYPE_NONE) {
+                                 ERROR_OUT(ALGO_ID_E, exit_sske);
+                             }
+@@ -31850,7 +31919,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                             /* only using sha and md5 for rsa */
+                         #ifndef NO_OLD_TLS
+                             hashType = WC_HASH_TYPE_SHA;
+-                            if (ssl->suites->sigAlgo == rsa_sa_algo) {
++                            if (ssl->options.sigAlgo == rsa_sa_algo) {
+                                 hashType = WC_HASH_TYPE_MD5_SHA;
+                             }
+                         #else
+@@ -31864,7 +31933,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ 
+                         ret = HashSkeData(ssl, hashType,
+                             args->output + preSigIdx, preSigSz,
+-                            ssl->suites->sigAlgo);
++                            ssl->options.sigAlgo);
+                         if (ret != 0) {
+                             goto exit_sske;
+                         }
+@@ -31872,7 +31941,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                         args->sigSz = args->tmpSigSz;
+ 
+                         /* Sign hash to create signature */
+-                        switch (ssl->suites->sigAlgo)
++                        switch (ssl->options.sigAlgo)
+                         {
+                         #ifndef NO_RSA
+                             case rsa_sa_algo:
+@@ -31890,7 +31959,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                         wc_EncodeSignature(encodedSig,
+                                             ssl->buffers.digest.buffer,
+                                             ssl->buffers.digest.length,
+-                                            TypeHash(ssl->suites->hashAlgo));
++                                            TypeHash(ssl->options.hashAlgo));
+ 
+                                     /* Replace sig buffer with new one */
+                                     XFREE(ssl->buffers.digest.buffer, ssl->heap,
+@@ -31902,7 +31971,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                         #endif /* NO_RSA */
+                             default:
+                                 break;
+-                        } /* switch (ssl->suites->sigAlgo) */
++                        } /* switch (ssl->options.sigAlgo) */
+                         break;
+                     }
+                 #endif /* !defined(NO_DH) && !defined(NO_RSA) */
+@@ -31948,7 +32017,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                     case ecc_diffie_hellman_kea:
+                     {
+                         /* Sign hash to create signature */
+-                        switch (ssl->suites->sigAlgo)
++                        switch (ssl->options.sigAlgo)
+                         {
+                         #ifndef NO_RSA
+                         #ifdef WC_RSA_PSS
+@@ -31963,7 +32032,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                     ssl->buffers.digest.length,
+                                     args->output + args->idx,
+                                     &args->sigSz,
+-                                    ssl->suites->sigAlgo, ssl->suites->hashAlgo,
++                                    ssl->options.sigAlgo, ssl->options.hashAlgo,
+                                     key,
+                                     ssl->buffers.key
+                                 );
+@@ -32040,7 +32109,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                     case diffie_hellman_kea:
+                     {
+                         /* Sign hash to create signature */
+-                        switch (ssl->suites->sigAlgo)
++                        switch (ssl->options.sigAlgo)
+                         {
+                         #ifndef NO_RSA
+                         #ifdef WC_RSA_PSS
+@@ -32059,7 +32128,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                     ssl->buffers.digest.length,
+                                     args->output + args->idx,
+                                     &args->sigSz,
+-                                    ssl->suites->sigAlgo, ssl->suites->hashAlgo,
++                                    ssl->options.sigAlgo, ssl->options.hashAlgo,
+                                     key,
+                                     ssl->buffers.key
+                                 );
+@@ -32068,7 +32137,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                         #endif /* NO_RSA */
+                             default:
+                                 break;
+-                        } /* switch (ssl->suites->sigAlgo) */
++                        } /* switch (ssl->options.sigAlgo) */
+ 
+                         break;
+                     }
+@@ -32117,7 +32186,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                                           defined(HAVE_CURVE448)
+                     case ecc_diffie_hellman_kea:
+                     {
+-                        switch(ssl->suites->sigAlgo)
++                        switch(ssl->options.sigAlgo)
+                         {
+                         #ifndef NO_RSA
+                         #ifdef WC_RSA_PSS
+@@ -32146,7 +32215,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                     args->verifySig, args->sigSz,
+                                     ssl->buffers.digest.buffer,
+                                     ssl->buffers.digest.length,
+-                                    ssl->suites->sigAlgo, ssl->suites->hashAlgo,
++                                    ssl->options.sigAlgo, ssl->options.hashAlgo,
+                                     key, ssl->buffers.key
+                                 );
+                                 break;
+@@ -32205,7 +32274,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                 #if !defined(NO_DH) && !defined(NO_RSA)
+                     case diffie_hellman_kea:
+                     {
+-                        switch (ssl->suites->sigAlgo)
++                        switch (ssl->options.sigAlgo)
+                         {
+                         #ifndef NO_RSA
+                         #ifndef WC_RSA_PSS
+@@ -32238,13 +32307,13 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                                     args->verifySig, args->sigSz,
+                                     ssl->buffers.digest.buffer,
+                                     ssl->buffers.digest.length,
+-                                    ssl->suites->sigAlgo, ssl->suites->hashAlgo,
++                                    ssl->options.sigAlgo, ssl->options.hashAlgo,
+                                     key, ssl->buffers.key
+                                 );
+                                 break;
+                             }
+                         #endif
+-                        } /* switch (ssl->suites->sigAlgo) */
++                        } /* switch (ssl->options.sigAlgo) */
+                         break;
+                     }
+                 #endif /* !defined(NO_DH) && !defined(NO_RSA) */
+@@ -32366,7 +32435,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+      * Returns 1 for valid server suite or 0 if not found
+      * For asynchronous this can return WC_PENDING_E
+      */
+-    static int VerifyServerSuite(WOLFSSL* ssl, word16 idx)
++    static int VerifyServerSuite(WOLFSSL* ssl, const Suites* suites, word16 idx)
+     {
+     #ifndef NO_PSK
+         int  havePSK = ssl->options.havePSK;
+@@ -32376,13 +32445,13 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ 
+         WOLFSSL_ENTER("VerifyServerSuite");
+ 
+-        if (ssl->suites == NULL) {
++        if (suites == NULL) {
+             WOLFSSL_MSG("Suites pointer error");
+             return 0;
+         }
+ 
+-        first   = ssl->suites->suites[idx];
+-        second  = ssl->suites->suites[idx+1];
++        first   = suites->suites[idx];
++        second  = suites->suites[idx+1];
+ 
+         if (CipherRequires(first, second, REQUIRES_RSA)) {
+             WOLFSSL_MSG("Requires RSA");
+@@ -32492,20 +32561,20 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+         return 1;
+     }
+ 
+-    static int CompareSuites(WOLFSSL* ssl, Suites* peerSuites, word16 i,
+-                             word16 j)
++    static int CompareSuites(WOLFSSL* ssl, const Suites* suites,
++            Suites* peerSuites, word16 i, word16 j)
+     {
+-        if (ssl->suites->suites[i]   == peerSuites->suites[j] &&
+-            ssl->suites->suites[i+1] == peerSuites->suites[j+1] ) {
++        if (suites->suites[i]   == peerSuites->suites[j] &&
++            suites->suites[i+1] == peerSuites->suites[j+1] ) {
+ 
+-            int ret = VerifyServerSuite(ssl, i);
++            int ret = VerifyServerSuite(ssl, suites, i);
+             if (ret < 0) {
+                 return ret;
+             }
+             if (ret) {
+                 WOLFSSL_MSG("Verified suite validity");
+-                ssl->options.cipherSuite0 = ssl->suites->suites[i];
+-                ssl->options.cipherSuite  = ssl->suites->suites[i+1];
++                ssl->options.cipherSuite0 = suites->suites[i];
++                ssl->options.cipherSuite  = suites->suites[i+1];
+                 ret = SetCipherSpecs(ssl);
+                 if (ret == 0) {
+                     ret = PickHashSigAlgo(ssl, peerSuites->hashSigAlgo,
+@@ -32525,6 +32594,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+     {
+         int ret;
+         word16 i, j;
++        const Suites* suites = WOLFSSL_SUITES(ssl);
+ 
+         WOLFSSL_ENTER("MatchSuite");
+ 
+@@ -32532,14 +32602,14 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+         if (peerSuites->suiteSz == 0 || peerSuites->suiteSz & 0x1)
+             return BUFFER_ERROR;
+ 
+-        if (ssl->suites == NULL)
++        if (suites == NULL)
+             return SUITES_ERROR;
+ 
+         if (!ssl->options.useClientOrder) {
+             /* Server order */
+-            for (i = 0; i < ssl->suites->suiteSz; i += 2) {
++            for (i = 0; i < suites->suiteSz; i += 2) {
+                 for (j = 0; j < peerSuites->suiteSz; j += 2) {
+-                    ret = CompareSuites(ssl, peerSuites, i, j);
++                    ret = CompareSuites(ssl, suites, peerSuites, i, j);
+                     if (ret != MATCH_SUITE_ERROR)
+                         return ret;
+                 }
+@@ -32548,8 +32618,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+         else {
+             /* Client order */
+             for (j = 0; j < peerSuites->suiteSz; j += 2) {
+-                for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-                    ret = CompareSuites(ssl, peerSuites, i, j);
++                for (i = 0; i < suites->suiteSz; i += 2) {
++                    ret = CompareSuites(ssl, suites, peerSuites, i, j);
+                     if (ret != MATCH_SUITE_ERROR)
+                         return ret;
+                 }
+@@ -32652,7 +32722,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ #ifndef NO_CERTS
+             keySz = ssl->buffers.keySz;
+ #endif
+-
++            ret = AllocateSuites(ssl);
++            if (ret != 0)
++                return ret;
+             InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+                        ssl->options.haveDH, ssl->options.haveECDSAsig,
+                        ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -33043,6 +33115,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+ #ifndef NO_CERTS
+             keySz = ssl->buffers.keySz;
+ #endif
++            ret = AllocateSuites(ssl);
++            if (ret != 0)
++                goto out;
+             InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+                        ssl->options.haveDH, ssl->options.haveECDSAsig,
+                        ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -33114,6 +33189,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                 keySz = ssl->buffers.keySz;
+             #endif
+ 
++                ret = AllocateSuites(ssl);
++                if (ret != 0)
++                    goto out;
+                 /* reset cipher suites to account for TLS version change */
+                 InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+                            ssl->options.haveDH, ssl->options.haveECDSAsig,
+diff --git a/src/ssl.c b/src/ssl.c
+index 1f693f530..60786bfe4 100644
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -2241,6 +2241,7 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
+         word16 havePSK;
+         word16 haveRSA;
+         int    keySz   = 0;
++        int    ret;
+ 
+     #ifndef NO_PSK
+         havePSK = ssl->options.havePSK;
+@@ -2255,6 +2256,9 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
+     #ifndef NO_CERTS
+         keySz = ssl->buffers.keySz;
+     #endif
++        ret = AllocateSuites(ssl);
++        if (ret != 0)
++            return ret;
+         InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+                    ssl->options.haveDH, ssl->options.haveECDSAsig,
+                    ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -3265,15 +3269,6 @@ static int _Rehandshake(WOLFSSL* ssl)
+             }
+         }
+ 
+-#ifndef NO_FORCE_SCR_SAME_SUITE
+-        /* force same suite */
+-        if (ssl->suites) {
+-            ssl->suites->suiteSz = SUITE_LEN;
+-            ssl->suites->suites[0] = ssl->options.cipherSuite0;
+-            ssl->suites->suites[1] = ssl->options.cipherSuite;
+-        }
+-#endif
+-
+         /* reset handshake states */
+         ssl->options.sendVerify = 0;
+         ssl->options.serverState = NULL_STATE;
+@@ -4819,6 +4814,8 @@ int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
+         keySz = ssl->buffers.keySz;
+     #endif
+ 
++    if (AllocateSuites(ssl) != 0)
++        return WOLFSSL_FAILURE;
+     InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+                ssl->options.haveDH, ssl->options.haveECDSAsig,
+                ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -6709,7 +6706,11 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
+             return WOLFSSL_BAD_FILE;
+         }
+ 
+-        if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
++        if (ssl) {
++            if (ssl->options.side == WOLFSSL_SERVER_END)
++                resetSuites = 1;
++        }
++        else if (ctx && ctx->method->side == WOLFSSL_SERVER_END) {
+             resetSuites = 1;
+         }
+         if (ssl && ssl->ctx->haveECDSAsig) {
+@@ -7062,16 +7063,18 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
+         word16 havePSK = 0;
+         word16 haveRSA = 0;
+ 
+-        #ifndef NO_PSK
++    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+         if (ssl->options.havePSK) {
+             havePSK = 1;
+         }
+-        #endif
+-        #ifndef NO_RSA
+-            haveRSA = 1;
+-        #endif
+-            keySz = ssl->buffers.keySz;
++    #endif
++    #ifndef NO_RSA
++        haveRSA = 1;
++    #endif
++        keySz = ssl->buffers.keySz;
+ 
++        if (AllocateSuites(ssl) != 0)
++            return WOLFSSL_FAILURE;
+         /* let's reset suites */
+         InitSuites(ssl->suites, ssl->version, keySz, haveRSA,
+                    havePSK, ssl->options.haveDH, ssl->options.haveECDSAsig,
+@@ -7079,6 +7082,34 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
+                    ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
+                    ssl->options.haveAnon, TRUE, ssl->options.side);
+     }
++    else if (ctx && resetSuites) {
++        word16 havePSK = 0;
++        word16 haveRSA = 0;
++
++    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
++        if (ctx->havePSK) {
++            havePSK = 1;
++        }
++    #endif
++    #ifndef NO_RSA
++        haveRSA = 1;
++    #endif
++        keySz = ctx->privateKeySz;
++
++        if (AllocateCtxSuites(ctx) != 0)
++            return WOLFSSL_FAILURE;
++        /* let's reset suites */
++        InitSuites(ctx->suites, ctx->method->version, keySz, haveRSA,
++                   havePSK, ctx->haveDH, ctx->haveECDSAsig,
++                   ctx->haveECC, TRUE, ctx->haveStaticECC,
++                   ctx->haveFalconSig, ctx->haveDilithiumSig,
++#ifdef HAVE_ANON
++                   ctx->haveAnon,
++#else
++                   FALSE,
++#endif
++                   TRUE, ctx->method->side);
++    }
+ 
+     return WOLFSSL_SUCCESS;
+ }
+@@ -11915,16 +11946,8 @@ int wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list)
+     if (ctx == NULL)
+         return WOLFSSL_FAILURE;
+ 
+-    /* alloc/init on demand only */
+-    if (ctx->suites == NULL) {
+-        ctx->suites = (Suites*)XMALLOC(sizeof(Suites), ctx->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-        if (ctx->suites == NULL) {
+-            WOLFSSL_MSG("Memory alloc for Suites failed");
+-            return WOLFSSL_FAILURE;
+-        }
+-        XMEMSET(ctx->suites, 0, sizeof(Suites));
+-    }
++    if (AllocateCtxSuites(ctx) != 0)
++        return WOLFSSL_FAILURE;
+ 
+ #ifdef OPENSSL_EXTRA
+     return wolfSSL_parse_cipher_list(ctx, ctx->suites, list);
+@@ -11943,16 +11966,8 @@ int wolfSSL_CTX_set_cipher_list_bytes(WOLFSSL_CTX* ctx, const byte* list,
+     if (ctx == NULL)
+         return WOLFSSL_FAILURE;
+ 
+-    /* alloc/init on demand only */
+-    if (ctx->suites == NULL) {
+-        ctx->suites = (Suites*)XMALLOC(sizeof(Suites), ctx->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-        if (ctx->suites == NULL) {
+-            WOLFSSL_MSG("Memory alloc for Suites failed");
+-            return WOLFSSL_FAILURE;
+-        }
+-        XMEMSET(ctx->suites, 0, sizeof(Suites));
+-    }
++    if (AllocateCtxSuites(ctx) != 0)
++        return WOLFSSL_FAILURE;
+ 
+     return (SetCipherListFromBytes(ctx, ctx->suites, list, listSz)) ?
+         WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+@@ -11967,18 +11982,8 @@ int wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list)
+         return WOLFSSL_FAILURE;
+     }
+ 
+-#ifdef SINGLE_THREADED
+-    if (ssl->ctx->suites == ssl->suites) {
+-        ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-        if (ssl->suites == NULL) {
+-            WOLFSSL_MSG("Suites Memory error");
+-            return MEMORY_E;
+-        }
+-        *ssl->suites = *ssl->ctx->suites;
+-        ssl->options.ownSuites = 1;
+-    }
+-#endif
++    if (AllocateSuites(ssl) != 0)
++        return WOLFSSL_FAILURE;
+ 
+ #ifdef OPENSSL_EXTRA
+     return wolfSSL_parse_cipher_list(ssl->ctx, ssl->suites, list);
+@@ -11999,18 +12004,8 @@ int wolfSSL_set_cipher_list_bytes(WOLFSSL* ssl, const byte* list,
+         return WOLFSSL_FAILURE;
+     }
+ 
+-#ifdef SINGLE_THREADED
+-    if (ssl->ctx->suites == ssl->suites) {
+-        ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-        if (ssl->suites == NULL) {
+-            WOLFSSL_MSG("Suites Memory error");
+-            return MEMORY_E;
+-        }
+-        *ssl->suites = *ssl->ctx->suites;
+-        ssl->options.ownSuites = 1;
+-    }
+-#endif
++    if (AllocateSuites(ssl) != 0)
++        return WOLFSSL_FAILURE;
+ 
+     return (SetCipherListFromBytes(ssl->ctx, ssl->suites, list, listSz))
+            ? WOLFSSL_SUCCESS
+@@ -15473,6 +15468,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
+         #ifndef NO_CERTS
+             keySz = ssl->buffers.keySz;
+         #endif
++        if (AllocateSuites(ssl) != 0)
++            return;
+         InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
+                    ssl->options.haveDH, ssl->options.haveECDSAsig,
+                    ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -15526,6 +15523,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
+         #ifndef NO_CERTS
+             keySz = ssl->buffers.keySz;
+         #endif
++        if (AllocateSuites(ssl) != 0)
++            return;
+         InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
+                    ssl->options.haveDH, ssl->options.haveECDSAsig,
+                    ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -23582,12 +23581,15 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
+     keySz = ssl->buffers.keySz;
+ #endif
+ 
+-    if (ssl->suites != NULL && ssl->options.side != WOLFSSL_NEITHER_END)
++    if (ssl->options.side != WOLFSSL_NEITHER_END) {
++        if (AllocateSuites(ssl) != 0)
++            return 0;
+         InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+                    ssl->options.haveDH, ssl->options.haveECDSAsig,
+                    ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+                    ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
+                    ssl->options.haveAnon, TRUE, ssl->options.side);
++    }
+ 
+     return ssl->options.mask;
+ }
+@@ -28340,16 +28342,8 @@ int wolfSSL_CTX_set1_sigalgs_list(WOLFSSL_CTX* ctx, const char* list)
+         return WOLFSSL_FAILURE;
+     }
+ 
+-    /* alloc/init on demand only */
+-    if (ctx->suites == NULL) {
+-        ctx->suites = (Suites*)XMALLOC(sizeof(Suites), ctx->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-        if (ctx->suites == NULL) {
+-            WOLFSSL_MSG("Memory alloc for Suites failed");
+-            return WOLFSSL_FAILURE;
+-        }
+-        XMEMSET(ctx->suites, 0, sizeof(Suites));
+-    }
++    if (AllocateCtxSuites(ctx) != 0)
++        return WOLFSSL_FAILURE;
+ 
+     return SetSuitesHashSigAlgo(ctx->suites, list);
+ }
+@@ -28361,27 +28355,13 @@ int wolfSSL_set1_sigalgs_list(WOLFSSL* ssl, const char* list)
+ {
+     WOLFSSL_MSG("wolfSSL_set1_sigalg_list");
+ 
+-    if (ssl == NULL) {
++    if (ssl == NULL || list == NULL) {
+         WOLFSSL_MSG("Bad function arguments");
+         return WOLFSSL_FAILURE;
+     }
+ 
+-#ifdef SINGLE_THREADED
+-    if (ssl->ctx->suites == ssl->suites) {
+-        ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
+-                                       DYNAMIC_TYPE_SUITES);
+-        if (ssl->suites == NULL) {
+-            WOLFSSL_MSG("Suites Memory error");
+-            return MEMORY_E;
+-        }
+-        *ssl->suites = *ssl->ctx->suites;
+-        ssl->options.ownSuites = 1;
+-    }
+-#endif
+-    if (ssl == NULL || list == NULL) {
+-        WOLFSSL_MSG("Bad function arguments");
++    if (AllocateSuites(ssl) != 0)
+         return WOLFSSL_FAILURE;
+-    }
+ 
+     return SetSuitesHashSigAlgo(ssl->suites, list);
+ }
+@@ -28482,8 +28462,8 @@ int wolfSSL_get_signature_nid(WOLFSSL *ssl, int* nid)
+     }
+ 
+     for (i = 0; i < WOLFSSL_HASH_SIG_INFO_SZ; i++) {
+-        if (ssl->suites->hashAlgo == wolfssl_hash_sig_info[i].hashAlgo &&
+-                     ssl->suites->sigAlgo == wolfssl_hash_sig_info[i].sigAlgo) {
++        if (ssl->options.hashAlgo == wolfssl_hash_sig_info[i].hashAlgo &&
++                     ssl->options.sigAlgo == wolfssl_hash_sig_info[i].sigAlgo) {
+             *nid = wolfssl_hash_sig_info[i].nid;
+             ret = WOLFSSL_SUCCESS;
+             break;
+@@ -33395,31 +33375,22 @@ static WC_INLINE int sslCipherMinMaxCheck(const WOLFSSL *ssl, byte suite0,
+ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
+ {
+     WOLF_STACK_OF(WOLFSSL_CIPHER)* ret = NULL;
+-    Suites* suites;
++    const Suites* suites;
+ #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+     const CipherSuiteInfo* cipher_names = GetCipherNames();
+     int cipherSz = GetCipherNamesSize();
+ #endif
+ 
+     WOLFSSL_ENTER("wolfSSL_get_ciphers_compat");
+-    if (ssl == NULL || (ssl->suites == NULL && ssl->ctx->suites == NULL)) {
++    if (ssl == NULL)
+         return NULL;
+-    }
+ 
+-    if (ssl->suites != NULL) {
+-        if (ssl->suites->suiteSz == 0 &&
+-                InitSSL_Suites((WOLFSSL*)ssl) != WOLFSSL_SUCCESS) {
+-            WOLFSSL_MSG("Suite initialization failure");
+-            return NULL;
+-        }
+-        suites = ssl->suites;
+-    }
+-    else {
+-        suites = ssl->ctx->suites;
+-    }
++    suites = WOLFSSL_SUITES(ssl);
++    if (suites == NULL)
++        return NULL;
+ 
+     /* check if stack needs populated */
+-    if (suites->stack == NULL) {
++    if (ssl->suitesStack == NULL) {
+         int i;
+ #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+         int j;
+@@ -33471,9 +33442,9 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
+                 ret = add;
+             }
+         }
+-        suites->stack = ret;
++        ((WOLFSSL*)ssl)->suitesStack = ret;
+     }
+-    return suites->stack;
++    return ssl->suitesStack;
+ }
+ #endif /* OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
+ 
+diff --git a/src/tls.c b/src/tls.c
+index 27c1002b2..2ad12935f 100644
+--- a/src/tls.c
++++ b/src/tls.c
+@@ -3943,13 +3943,14 @@ static void TLSX_SupportedCurve_ValidateRequest(const WOLFSSL* ssl,
+ static void TLSX_SupportedCurve_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
+ {
+     word16 i;
++    const Suites* suites = WOLFSSL_SUITES(ssl);
+ 
+-    for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-        if (ssl->suites->suites[i] == TLS13_BYTE)
++    for (i = 0; i < suites->suiteSz; i += 2) {
++        if (suites->suites[i] == TLS13_BYTE)
+             return;
+-        if ((ssl->suites->suites[i] == ECC_BYTE) ||
+-            (ssl->suites->suites[i] == ECDHE_PSK_BYTE) ||
+-            (ssl->suites->suites[i] == CHACHA_BYTE)) {
++        if ((suites->suites[i] == ECC_BYTE) ||
++            (suites->suites[i] == ECDHE_PSK_BYTE) ||
++            (suites->suites[i] == CHACHA_BYTE)) {
+         #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) || \
+                                                           defined(HAVE_CURVE448)
+             return;
+@@ -3971,24 +3972,28 @@ static void TLSX_SupportedCurve_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
+  */
+ static void TLSX_PointFormat_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
+ {
++#ifdef HAVE_FFDHE
++    (void)ssl;
++    (void)semaphore;
++#else
+     word16 i;
++    const Suites* suites = WOLFSSL_SUITES(ssl);
+ 
+-    for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-        if (ssl->suites->suites[i] == TLS13_BYTE)
++    if (suites == NULL)
++        return;
++
++    for (i = 0; i < suites->suiteSz; i += 2) {
++        if (suites->suites[i] == TLS13_BYTE)
+             return;
+-        if ((ssl->suites->suites[i] == ECC_BYTE) ||
+-            (ssl->suites->suites[i] == ECDHE_PSK_BYTE) ||
+-            (ssl->suites->suites[i] == CHACHA_BYTE)) {
++        if ((suites->suites[i] == ECC_BYTE) ||
++            (suites->suites[i] == ECDHE_PSK_BYTE) ||
++            (suites->suites[i] == CHACHA_BYTE)) {
+         #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) || \
+                                                           defined(HAVE_CURVE448)
+             return;
+         #endif
+         }
+     }
+-#ifdef HAVE_FFDHE
+-    (void)semaphore;
+-    return;
+-#else
+    /* turns semaphore on to avoid sending this extension. */
+    TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_EC_POINT_FORMATS));
+ #endif
+@@ -6368,9 +6373,12 @@ int TLSX_Cookie_Use(WOLFSSL* ssl, const byte* data, word16 len, byte* mac,
+ 
+ static word16 TLSX_SignatureAlgorithms_GetSize(void* data)
+ {
+-    WOLFSSL* ssl = (WOLFSSL*)data;
++    SignatureAlgorithms* sa = (SignatureAlgorithms*)data;
+ 
+-    return OPAQUE16_LEN + ssl->suites->hashSigAlgoSz;
++    if (sa->hashSigAlgoSz == 0)
++        return OPAQUE16_LEN + WOLFSSL_SUITES(sa->ssl)->hashSigAlgoSz;
++    else
++        return OPAQUE16_LEN + sa->hashSigAlgoSz;
+ }
+ 
+ /* Creates a bit string of supported hash algorithms with RSA PSS.
+@@ -6414,16 +6422,27 @@ static int TLSX_SignatureAlgorithms_MapPss(WOLFSSL *ssl, const byte* input,
+  */
+ static word16 TLSX_SignatureAlgorithms_Write(void* data, byte* output)
+ {
+-    WOLFSSL* ssl = (WOLFSSL*)data;
++    SignatureAlgorithms* sa = (SignatureAlgorithms*)data;
++    const Suites* suites = WOLFSSL_SUITES(sa->ssl);
++    word16 hashSigAlgoSz;
+ 
+-    c16toa(ssl->suites->hashSigAlgoSz, output);
+-    XMEMCPY(output + OPAQUE16_LEN, ssl->suites->hashSigAlgo,
+-            ssl->suites->hashSigAlgoSz);
++    if (sa->hashSigAlgoSz == 0) {
++        c16toa(suites->hashSigAlgoSz, output);
++        XMEMCPY(output + OPAQUE16_LEN, suites->hashSigAlgo,
++                suites->hashSigAlgoSz);
++        hashSigAlgoSz = suites->hashSigAlgoSz;
++    }
++    else {
++        c16toa(sa->hashSigAlgoSz, output);
++        XMEMCPY(output + OPAQUE16_LEN, sa->hashSigAlgo,
++                sa->hashSigAlgoSz);
++        hashSigAlgoSz = sa->hashSigAlgoSz;
++    }
+ 
+-    TLSX_SignatureAlgorithms_MapPss(ssl, output + OPAQUE16_LEN,
+-                                    ssl->suites->hashSigAlgoSz);
++    TLSX_SignatureAlgorithms_MapPss(sa->ssl, output + OPAQUE16_LEN,
++            hashSigAlgoSz);
+ 
+-    return OPAQUE16_LEN + ssl->suites->hashSigAlgoSz;
++    return OPAQUE16_LEN + hashSigAlgoSz;
+ }
+ 
+ /* Parse the SignatureAlgorithms extension.
+@@ -6474,18 +6493,56 @@ static int TLSX_SignatureAlgorithms_Parse(WOLFSSL *ssl, const byte* input,
+  * heap        The heap used for allocation.
+  * returns 0 on success, otherwise failure.
+  */
+-static int TLSX_SetSignatureAlgorithms(TLSX** extensions, const void* data,
++static int TLSX_SetSignatureAlgorithms(TLSX** extensions, WOLFSSL* ssl,
+                                        void* heap)
+ {
++    SignatureAlgorithms* sa;
++    int ret;
++
+     if (extensions == NULL)
+         return BAD_FUNC_ARG;
+ 
+-    return TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS, data, heap);
++    /* Already present */
++    if (TLSX_Find(*extensions, TLSX_SIGNATURE_ALGORITHMS) != NULL)
++        return 0;
++
++    sa = TLSX_SignatureAlgorithms_New(ssl, 0, heap);
++    if (sa == NULL)
++        return MEMORY_ERROR;
++
++    ret = TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS, sa, heap);
++    if (ret != 0)
++        TLSX_SignatureAlgorithms_FreeAll(sa, heap);
++    return ret;
++}
++
++SignatureAlgorithms* TLSX_SignatureAlgorithms_New(WOLFSSL* ssl,
++        word16 hashSigAlgoSz, void* heap)
++{
++    SignatureAlgorithms* sa;
++    (void)heap;
++
++    sa = (SignatureAlgorithms*)XMALLOC(sizeof(*sa) + hashSigAlgoSz, heap,
++                                       DYNAMIC_TYPE_TLSX);
++    if (sa != NULL) {
++        XMEMSET(sa, 0, sizeof(*sa) + hashSigAlgoSz);
++        sa->ssl = ssl;
++        sa->hashSigAlgoSz = hashSigAlgoSz;
++    }
++    return sa;
++}
++
++void TLSX_SignatureAlgorithms_FreeAll(SignatureAlgorithms* sa,
++                                             void* heap)
++{
++    XFREE(sa, heap, DYNAMIC_TYPE_TLSX);
++    (void)heap;
+ }
+ 
+ #define SA_GET_SIZE  TLSX_SignatureAlgorithms_GetSize
+ #define SA_WRITE     TLSX_SignatureAlgorithms_Write
+ #define SA_PARSE     TLSX_SignatureAlgorithms_Parse
++#define SA_FREE_ALL  TLSX_SignatureAlgorithms_FreeAll
+ #endif
+ /******************************************************************************/
+ /* Signature Algorithms Certificate                                           */
+@@ -6565,8 +6622,8 @@ static int TLSX_SignatureAlgorithmsCert_Parse(WOLFSSL *ssl, const byte* input,
+  * heap        The heap used for allocation.
+  * returns 0 on success, otherwise failure.
+  */
+-static int TLSX_SetSignatureAlgorithmsCert(TLSX** extensions, const void* data,
+-                                           void* heap)
++static int TLSX_SetSignatureAlgorithmsCert(TLSX** extensions,
++        const WOLFSSL* data, void* heap)
+ {
+     if (extensions == NULL)
+         return BAD_FUNC_ARG;
+@@ -10274,6 +10331,7 @@ void TLSX_FreeAll(TLSX* list, void* heap)
+                 break;
+ #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
+             case TLSX_SIGNATURE_ALGORITHMS:
++                SA_FREE_ALL((SignatureAlgorithms*)extension->data, heap);
+                 break;
+ #endif
+ #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
+@@ -11205,9 +11263,10 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
+         #ifndef WOLFSSL_PSK_ONE_ID
+             if (ssl->options.client_psk_cs_cb != NULL) {
+                 int i;
+-                for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-                    byte cipherSuite0 = ssl->suites->suites[i + 0];
+-                    byte cipherSuite = ssl->suites->suites[i + 1];
++                const Suites* suites = WOLFSSL_SUITES(ssl);
++                for (i = 0; i < suites->suiteSz; i += 2) {
++                    byte cipherSuite0 = suites->suites[i + 0];
++                    byte cipherSuite = suites->suites[i + 1];
+                     unsigned int keySz;
+                 #ifdef WOLFSSL_PSK_MULTI_ID_PER_CS
+                     int cnt = 0;
+@@ -11242,7 +11301,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
+                             ret = TLSX_PreSharedKey_Use(ssl,
+                                 (byte*)ssl->arrays->client_identity,
+                                 (word16)XSTRLEN(ssl->arrays->client_identity),
+-                                0, SuiteMac(ssl->suites->suites + i),
++                                0, SuiteMac(WOLFSSL_SUITES(ssl)->suites + i),
+                                 cipherSuite0, cipherSuite, 0, NULL);
+                             if (ret != 0)
+                                 return ret;
+@@ -11383,7 +11442,7 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word16* pLength)
+         PF_VALIDATE_REQUEST(ssl, semaphore);
+         WOLF_STK_VALIDATE_REQUEST(ssl);
+ #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
+-        if (ssl->suites->hashSigAlgoSz == 0)
++        if (WOLFSSL_SUITES(ssl)->hashSigAlgoSz == 0)
+             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS));
+ #endif
+ #if defined(WOLFSSL_TLS13)
+@@ -11476,7 +11535,7 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word16* pOffset)
+         PF_VALIDATE_REQUEST(ssl, semaphore);
+         WOLF_STK_VALIDATE_REQUEST(ssl);
+ #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
+-        if (ssl->suites->hashSigAlgoSz == 0)
++        if (WOLFSSL_SUITES(ssl)->hashSigAlgoSz == 0)
+             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS));
+ #endif
+ #ifdef WOLFSSL_TLS13
+diff --git a/src/tls13.c b/src/tls13.c
+index 42eb7ffce..61773de8d 100644
+--- a/src/tls13.c
++++ b/src/tls13.c
+@@ -3232,10 +3232,11 @@ exit_buildmsg:
+ static int FindSuiteSSL(WOLFSSL* ssl, byte* suite)
+ {
+     word16 i;
++    const Suites* suites = WOLFSSL_SUITES(ssl);
+ 
+-    for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-        if (ssl->suites->suites[i+0] == suite[0] &&
+-            ssl->suites->suites[i+1] == suite[1]) {
++    for (i = 0; i < suites->suiteSz; i += 2) {
++        if (suites->suites[i+0] == suite[0] &&
++                suites->suites[i+1] == suite[1]) {
+             return 1;
+         }
+     }
+@@ -3250,7 +3251,7 @@ static int FindSuiteSSL(WOLFSSL* ssl, byte* suite)
+  * @param [in] suite.
+  * @return  A value from wc_MACAlgorithm enumeration.
+  */
+-byte SuiteMac(byte* suite)
++byte SuiteMac(const byte* suite)
+ {
+     byte mac = no_mac;
+ 
+@@ -3856,6 +3857,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
+     Sch13Args  args[1];
+ #endif
+     byte major, tls12minor;
++    const Suites* suites;
+ 
+ 
+     WOLFSSL_START(WC_FUNC_CLIENT_HELLO_SEND);
+@@ -3898,7 +3900,8 @@ int SendTls13ClientHello(WOLFSSL* ssl)
+     }
+ #endif
+ 
+-    if (ssl->suites == NULL) {
++    suites = WOLFSSL_SUITES(ssl);
++    if (suites == NULL) {
+         WOLFSSL_MSG("Bad suites pointer in SendTls13ClientHello");
+         return SUITES_ERROR;
+     }
+@@ -3940,7 +3943,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
+ #endif /* WOLFSSL_DTLS13 */
+ 
+     /* Version | Random | Session Id | Cipher Suites | Compression */
+-    args->length = VERSION_SZ + RAN_LEN + ENUM_LEN + ssl->suites->suiteSz +
++    args->length = VERSION_SZ + RAN_LEN + ENUM_LEN + suites->suiteSz +
+             SUITE_LEN + COMP_LEN + ENUM_LEN;
+ #ifdef WOLFSSL_QUIC
+     if (WOLFSSL_IS_QUIC(ssl)) {
+@@ -4101,18 +4104,18 @@ int SendTls13ClientHello(WOLFSSL* ssl)
+ #endif /* WOLFSSL_DTLS13 */
+ 
+     /* Cipher suites */
+-    c16toa(ssl->suites->suiteSz, args->output + args->idx);
++    c16toa(suites->suiteSz, args->output + args->idx);
+     args->idx += OPAQUE16_LEN;
+-    XMEMCPY(args->output + args->idx, &ssl->suites->suites,
+-        ssl->suites->suiteSz);
+-    args->idx += ssl->suites->suiteSz;
++    XMEMCPY(args->output + args->idx, &suites->suites,
++        suites->suiteSz);
++    args->idx += suites->suiteSz;
+ #ifdef WOLFSSL_DEBUG_TLS
+     {
+         int ii;
+         WOLFSSL_MSG("Ciphers:");
+-        for (ii = 0 ; ii < ssl->suites->suiteSz; ii += 2) {
+-            WOLFSSL_MSG(GetCipherNameInternal(ssl->suites->suites[ii+0],
+-                                              ssl->suites->suites[ii+1]));
++        for (ii = 0 ; ii < suites->suiteSz; ii += 2) {
++            WOLFSSL_MSG(GetCipherNameInternal(suites->suites[ii+0],
++                                              suites->suites[ii+1]));
+         }
+     }
+ #endif
+@@ -4956,6 +4959,9 @@ static void RefineSuites(WOLFSSL* ssl, Suites* peerSuites)
+     word16 i;
+     word16 j;
+ 
++    if (AllocateSuites(ssl) != 0)
++        return;
++
+     XMEMSET(suites, 0, WOLFSSL_MAX_SUITE_SZ);
+ 
+     if (!ssl->options.useClientOrder) {
+@@ -5018,7 +5024,7 @@ static void RefineSuites(WOLFSSL* ssl, Suites* peerSuites)
+  * @return  1 when a match found - but check error code.
+  * @return  0 when no match found.
+  */
+-static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
++static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
+ {
+     int         ret = 0;
+     int         found = 0;
+@@ -5054,9 +5060,13 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
+             found = (suite[0] == cipherSuite0) && (suite[1] == cipherSuite);
+         #else
+             /* Check whether PSK ciphersuite is in SSL. */
+-            suite[0] = cipherSuite0;
+-            suite[1] = cipherSuite;
+-            found = FindSuiteSSL(ssl, suite);
++            {
++                byte s[2] = {
++                    cipherSuite0,
++                    cipherSuite,
++                };
++                found = FindSuiteSSL(ssl, s);
++            }
+         #endif
+         }
+         if ((ret == 0) && found) {
+@@ -5073,8 +5083,8 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
+         }
+         if ((ret == 0) && found) {
+             /* Set PSK ciphersuite into SSL. */
+-            ssl->options.cipherSuite0 = suite[0];
+-            ssl->options.cipherSuite  = suite[1];
++            ssl->options.cipherSuite0 = cipherSuite0;
++            ssl->options.cipherSuite  = cipherSuite;
+             ret = SetCipherSpecs(ssl);
+         }
+         if ((ret == 0) && found) {
+@@ -5104,7 +5114,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
+  * returns 0 on success and otherwise failure.
+  */
+ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
+-    byte* suite, int* usingPSK, int* first)
++    const byte* suite, int* usingPSK, int* first)
+ {
+     int           ret = 0;
+     TLSX*         ext;
+@@ -5194,11 +5204,15 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
+                 continue;
+             }
+         #else
+-            suite[0] = ssl->session->cipherSuite0;
+-            suite[1] = ssl->session->cipherSuite;
+-            if (!FindSuiteSSL(ssl, suite)) {
+-                current = current->next;
+-                continue;
++            {
++                byte s[2] = {
++                    ssl->session->cipherSuite0,
++                    ssl->session->cipherSuite,
++                };
++                if (!FindSuiteSSL(ssl, s)) {
++                    current = current->next;
++                    continue;
++                }
+             }
+         #endif
+ 
+@@ -5326,6 +5340,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
+     int    first = 0;
+ #ifndef WOLFSSL_PSK_ONE_ID
+     int    i;
++    const Suites* suites = WOLFSSL_SUITES(ssl);
+ #else
+     byte   suite[2];
+ #endif
+@@ -5370,9 +5385,9 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
+ 
+     /* Server list has only common suites from refining in server or client
+      * order. */
+-    for (i = 0; !(*usingPSK) && i < ssl->suites->suiteSz; i += 2) {
++    for (i = 0; !(*usingPSK) && i < suites->suiteSz; i += 2) {
+         ret = DoPreSharedKeys(ssl, input, helloSz - bindersLen,
+-            ssl->suites->suites + i, usingPSK, &first);
++                suites->suites + i, usingPSK, &first);
+         if (ret != 0) {
+             return ret;
+         }
+@@ -6605,21 +6620,30 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
+     int    sendSz;
+     word32 i;
+     word16 reqSz;
+-    TLSX*  ext;
++    word16 hashSigAlgoSz = 0;
++    SignatureAlgorithms* sa;
+ 
+     WOLFSSL_START(WC_FUNC_CERTIFICATE_REQUEST_SEND);
+     WOLFSSL_ENTER("SendTls13CertificateRequest");
+ 
+     ssl->options.buildingMsg = 1;
+ 
+-    if (ssl->options.side == WOLFSSL_SERVER_END)
+-        InitSuitesHashSigAlgo(ssl->suites, 1, 1, 1, 1,
+-                              0, 1, ssl->buffers.keySz);
++    if (ssl->options.side != WOLFSSL_SERVER_END)
++        return SIDE_ERROR;
+ 
+-    ext = TLSX_Find(ssl->extensions, TLSX_SIGNATURE_ALGORITHMS);
+-    if (ext == NULL)
+-        return EXT_MISSING;
+-    ext->resp = 0;
++    /* Get the length of the hashSigAlgo buffer */
++    InitSuitesHashSigAlgo_ex(NULL, 1, 1, 1, 1, 0, 1, ssl->buffers.keySz,
++                             &hashSigAlgoSz);
++    sa = TLSX_SignatureAlgorithms_New(ssl, hashSigAlgoSz, ssl->heap);
++    if (sa == NULL)
++        return MEMORY_ERROR;
++    InitSuitesHashSigAlgo_ex(sa->hashSigAlgo, 1, 1, 1, 1, 0, 1,
++                             ssl->buffers.keySz, &sa->hashSigAlgoSz);
++    ret = TLSX_Push(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, sa, ssl->heap);
++    if (ret != 0) {
++        TLSX_SignatureAlgorithms_FreeAll(sa, ssl->heap);
++        return ret;
++    }
+ 
+     i = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
+ #ifdef WOLFSSL_DTLS13
+@@ -7761,7 +7785,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
+             else {
+                 ERROR_OUT(ALGO_ID_E, exit_scv);
+             }
+-            EncodeSigAlg(ssl->suites->hashAlgo, args->sigAlgo, args->verify);
++            EncodeSigAlg(ssl->options.hashAlgo, args->sigAlgo, args->verify);
+ 
+             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
+                 int sigLen = MAX_SIG_DATA_SZ;
+@@ -7794,7 +7818,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
+                 }
+ 
+                 ret = CreateRSAEncodedSig(sig->buffer, args->sigData,
+-                    args->sigDataSz, args->sigAlgo, ssl->suites->hashAlgo);
++                    args->sigDataSz, args->sigAlgo, ssl->options.hashAlgo);
+                 if (ret < 0)
+                     goto exit_scv;
+                 sig->length = ret;
+@@ -7809,7 +7833,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
+                 sig->length = args->sendSz - args->idx - HASH_SIG_SIZE -
+                               VERIFY_HEADER;
+                 ret = CreateECCEncodedSig(args->sigData,
+-                    args->sigDataSz, ssl->suites->hashAlgo);
++                    args->sigDataSz, ssl->options.hashAlgo);
+                 if (ret < 0)
+                     goto exit_scv;
+                 args->sigDataSz = (word16)ret;
+@@ -7920,7 +7944,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
+             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
+                 ret = RsaSign(ssl, sig->buffer, (word32)sig->length,
+                     args->verify + HASH_SIG_SIZE + VERIFY_HEADER, &args->sigLen,
+-                    args->sigAlgo, ssl->suites->hashAlgo,
++                    args->sigAlgo, ssl->options.hashAlgo,
+                     (RsaKey*)ssl->hsKey,
+                     ssl->buffers.key
+                 );
+@@ -7954,7 +7978,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
+                 /* check for signature faults */
+                 ret = VerifyRsaSign(ssl, args->sigData, args->sigLen,
+                     sig->buffer, (word32)sig->length, args->sigAlgo,
+-                    ssl->suites->hashAlgo, (RsaKey*)ssl->hsKey,
++                    ssl->options.hashAlgo, (RsaKey*)ssl->hsKey,
+                     ssl->buffers.key
+                 );
+             }
+@@ -11706,6 +11730,8 @@ void wolfSSL_set_psk_client_cs_callback(WOLFSSL* ssl,
+     #ifndef NO_CERTS
+         keySz = ssl->buffers.keySz;
+     #endif
++    if (AllocateSuites(ssl) != 0)
++        return;
+     InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
+                ssl->options.haveDH, ssl->options.haveECDSAsig,
+                ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -11757,6 +11783,8 @@ void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
+     #ifndef NO_CERTS
+         keySz = ssl->buffers.keySz;
+     #endif
++    if (AllocateSuites(ssl) != 0)
++        return;
+     InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
+                ssl->options.haveDH, ssl->options.haveECDSAsig,
+                ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -11805,6 +11833,8 @@ void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
+     #ifndef NO_CERTS
+         keySz = ssl->buffers.keySz;
+     #endif
++    if (AllocateSuites(ssl) != 0)
++        return;
+     InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
+                ssl->options.haveDH, ssl->options.haveECDSAsig,
+                ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+@@ -11824,6 +11854,7 @@ const char* wolfSSL_get_cipher_name_by_hash(WOLFSSL* ssl, const char* hash)
+     const char* name = NULL;
+     byte mac = no_mac;
+     int i;
++    const Suites* suites = WOLFSSL_SUITES(ssl);
+ 
+     if (XSTRCMP(hash, "SHA256") == 0) {
+         mac = sha256_mac;
+@@ -11832,10 +11863,10 @@ const char* wolfSSL_get_cipher_name_by_hash(WOLFSSL* ssl, const char* hash)
+         mac = sha384_mac;
+     }
+     if (mac != no_mac) {
+-        for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-            if (SuiteMac(ssl->suites->suites + i) == mac) {
+-                name = GetCipherNameInternal(ssl->suites->suites[i + 0],
+-                                             ssl->suites->suites[i + 1]);
++        for (i = 0; i < suites->suiteSz; i += 2) {
++            if (SuiteMac(suites->suites + i) == mac) {
++                name = GetCipherNameInternal(suites->suites[i + 0],
++                                             suites->suites[i + 1]);
+                 break;
+             }
+         }
+diff --git a/tests/api.c b/tests/api.c
+index 77bde7d24..b02ab7ac5 100644
+--- a/tests/api.c
++++ b/tests/api.c
+@@ -9226,7 +9226,60 @@ static int test_wolfSSL_wolfSSL_UseSecureRenegotiation(void)
+     return res;
+ }
+ 
+-#if !defined(NO_WOLFSSL_SERVER) && (!defined(NO_RSA) || defined(HAVE_ECC))
++/* Test reconnecting with a different ciphersuite after a renegotiation. */
++static int test_wolfSSL_SCR_Reconnect(void)
++{
++    int res = TEST_SKIPPED;
++
++#if defined(HAVE_SECURE_RENEGOTIATION) && \
++    defined(BUILD_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) && \
++    defined(BUILD_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
++    struct test_memio_ctx test_ctx;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
++    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
++    byte data;
++
++    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
++    test_ctx.c_ciphers = "ECDHE-RSA-AES256-GCM-SHA384";
++    test_ctx.s_ciphers =
++        "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305";
++    AssertIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
++        wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
++    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseSecureRenegotiation(ctx_c));
++    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseSecureRenegotiation(ctx_s));
++    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseSecureRenegotiation(ssl_c));
++    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseSecureRenegotiation(ssl_s));
++    AssertIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
++    /* WOLFSSL_FATAL_ERROR since it will block */
++    AssertIntEQ(wolfSSL_Rehandshake(ssl_s), WOLFSSL_FATAL_ERROR);
++    AssertIntEQ(wolfSSL_get_error(ssl_s, WOLFSSL_FATAL_ERROR),
++                WOLFSSL_ERROR_WANT_READ);
++    AssertIntEQ(wolfSSL_read(ssl_c, &data, 1), WOLFSSL_FATAL_ERROR);
++    AssertIntEQ(wolfSSL_get_error(ssl_s, WOLFSSL_FATAL_ERROR),
++                WOLFSSL_ERROR_WANT_READ);
++    AssertIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
++    wolfSSL_free(ssl_c);
++    ssl_c = NULL;
++    wolfSSL_free(ssl_s);
++    ssl_s = NULL;
++    wolfSSL_CTX_free(ctx_c);
++    ctx_c = NULL;
++    test_ctx.c_ciphers = "ECDHE-RSA-CHACHA20-POLY1305";
++    AssertIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
++        wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
++    AssertIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
++    wolfSSL_free(ssl_s);
++    wolfSSL_free(ssl_c);
++    wolfSSL_CTX_free(ctx_s);
++    wolfSSL_CTX_free(ctx_c);
++
++    res = TEST_RES_CHECK(1);
++#endif
++    return res;
++}
++
++#if !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_SERVER) && \
++    (!defined(NO_RSA) || defined(HAVE_ECC))
+ /* Called when writing. */
+ static int DummySend(WOLFSSL* ssl, char* buf, int sz, void* ctx)
+ {
+@@ -50587,10 +50640,13 @@ static int test_tls13_cipher_suites(void)
+     wolfSSL_SetIOReadCtx(ssl, &msg);
+     /* Force server to have as many occurrences of same cipher suite as
+      * possible. */
+-    ssl->suites->suiteSz = WOLFSSL_MAX_SUITE_SZ;
+-    for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+-        ssl->suites->suites[i + 0] = TLS13_BYTE;
+-        ssl->suites->suites[i + 1] = TLS_AES_128_GCM_SHA256;
++    {
++        Suites* suites = (Suites*)WOLFSSL_SUITES(ssl);
++        suites->suiteSz = WOLFSSL_MAX_SUITE_SZ;
++        for (i = 0; i < suites->suiteSz; i += 2) {
++            suites->suites[i + 0] = TLS13_BYTE;
++            suites->suites[i + 1] = TLS_AES_128_GCM_SHA256;
++        }
+     }
+     /* Test multiple occurrences of same cipher suite. */
+     wolfSSL_accept_TLSv13(ssl);
+@@ -59046,9 +59102,9 @@ static int test_wolfSSL_DTLS_fragment_buckets(void)
+ 
+ static int test_wolfSSL_dtls_stateless2(void)
+ {
+-    WOLFSSL *ssl_c, *ssl_c2, *ssl_s;
++    WOLFSSL *ssl_c = NULL, *ssl_c2 = NULL, *ssl_s = NULL;
+     struct test_memio_ctx test_ctx;
+-    WOLFSSL_CTX *ctx_c, *ctx_s;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+     int ret;
+ 
+     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+@@ -59086,9 +59142,9 @@ static int test_wolfSSL_dtls_stateless2(void)
+ #ifdef HAVE_MAX_FRAGMENT
+ static int test_wolfSSL_dtls_stateless_maxfrag(void)
+ {
+-    WOLFSSL *ssl_c, *ssl_c2, *ssl_s;
++    WOLFSSL *ssl_c = NULL, *ssl_c2 = NULL, *ssl_s = NULL;
+     struct test_memio_ctx test_ctx;
+-    WOLFSSL_CTX *ctx_c, *ctx_s;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+     word16 max_fragment;
+     int ret;
+ 
+@@ -59146,8 +59202,8 @@ static int buf_is_hvr(const byte *data, int len)
+ static int _test_wolfSSL_dtls_stateless_resume(byte useticket, byte bad)
+ {
+     struct test_memio_ctx test_ctx;
+-    WOLFSSL_CTX *ctx_c, *ctx_s;
+-    WOLFSSL *ssl_c, *ssl_s;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
++    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+     WOLFSSL_SESSION *sess;
+     int ret, round_trips;
+ 
+@@ -59248,8 +59304,8 @@ static int test_wolfSSL_dtls_stateless_resume(void)
+ #if !defined(NO_OLD_TLS)
+ static int test_wolfSSL_dtls_stateless_downgrade(void)
+ {
+-    WOLFSSL_CTX *ctx_c, *ctx_c2, *ctx_s;
+-    WOLFSSL *ssl_c, *ssl_c2, *ssl_s;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_c2 = NULL, *ctx_s = NULL;
++    WOLFSSL *ssl_c = NULL, *ssl_c2 = NULL, *ssl_s = NULL;
+     struct test_memio_ctx test_ctx;
+     int ret;
+ 
+@@ -59305,8 +59361,8 @@ static int test_wolfSSL_dtls_stateless_downgrade(void)
+ static int test_WOLFSSL_dtls_version_alert(void)
+ {
+     struct test_memio_ctx test_ctx;
+-    WOLFSSL_CTX *ctx_c, *ctx_s;
+-    WOLFSSL *ssl_c, *ssl_s;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
++    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+     int ret;
+ 
+     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+@@ -59481,9 +59537,9 @@ static int test_ticket_nonce_cache(WOLFSSL *ssl_s, WOLFSSL *ssl_c, byte len)
+ static int test_ticket_nonce_malloc(void)
+ {
+     struct test_memio_ctx test_ctx;
+-    WOLFSSL_CTX *ctx_c, *ctx_s;
++    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
++    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+     byte small, medium, big;
+-    WOLFSSL *ssl_c, *ssl_s;
+     int ret;
+ 
+     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+@@ -59659,6 +59715,7 @@ TEST_CASE testCases[] = {
+ #endif
+     TEST_DECL(test_wolfSSL_DisableExtendedMasterSecret),
+     TEST_DECL(test_wolfSSL_wolfSSL_UseSecureRenegotiation),
++    TEST_DECL(test_wolfSSL_SCR_Reconnect),
+     TEST_DECL(test_tls_ext_duplicate),
+ 
+     /* X509 tests */
+diff --git a/wolfcrypt/src/evp.c b/wolfcrypt/src/evp.c
+index 87e82793f..5f6acc60c 100644
+--- a/wolfcrypt/src/evp.c
++++ b/wolfcrypt/src/evp.c
+@@ -7081,23 +7081,24 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
+                            word32 len)
+     {
+         int ret = WOLFSSL_FAILURE;
+-
+         WOLFSSL_ENTER("wolfSSL_EVP_Cipher");
+ 
+         if (ctx == NULL || ((src == NULL || dst == NULL) &&
+-            (ctx->cipherType != AES_128_GCM_TYPE &&
++            (TRUE
++        #ifdef HAVE_AESGCM
++            && ctx->cipherType != AES_128_GCM_TYPE &&
+              ctx->cipherType != AES_192_GCM_TYPE &&
+-             ctx->cipherType != AES_256_GCM_TYPE))) {
++             ctx->cipherType != AES_256_GCM_TYPE
++        #endif
++            ))) {
+             WOLFSSL_MSG("Bad argument.");
+             return WOLFSSL_FATAL_ERROR;
+         }
+-
+         if (ctx->cipherType == WOLFSSL_EVP_CIPH_TYPE_INIT) {
+             WOLFSSL_MSG("Cipher operation not initialized. Call "
+                         "wolfSSL_EVP_CipherInit.");
+             return WOLFSSL_FATAL_ERROR;
+         }
+-
+         switch (ctx->cipherType) {
+ 
+ #ifndef NO_AES
+diff --git a/wolfssl/internal.h b/wolfssl/internal.h
+index 0f3abf1b0..2806f252d 100644
+--- a/wolfssl/internal.h
++++ b/wolfssl/internal.h
+@@ -1931,6 +1931,7 @@ typedef struct Suites Suites;
+ /* defaults to client */
+ WOLFSSL_LOCAL void InitSSL_Method(WOLFSSL_METHOD* method, ProtocolVersion pv);
+ 
++WOLFSSL_LOCAL void InitSSL_CTX_Suites(WOLFSSL_CTX* ctx);
+ WOLFSSL_LOCAL int InitSSL_Suites(WOLFSSL* ssl);
+ WOLFSSL_LOCAL int InitSSL_Side(WOLFSSL* ssl, word16 side);
+ 
+@@ -1947,7 +1948,7 @@ WOLFSSL_LOCAL int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx,
+ WOLFSSL_LOCAL int  HandleTlsResumption(WOLFSSL* ssl, int bogusID,
+                                        Suites* clSuites);
+ #ifdef WOLFSSL_TLS13
+-WOLFSSL_LOCAL byte SuiteMac(byte* suite);
++WOLFSSL_LOCAL byte SuiteMac(const byte* suite);
+ #endif
+ WOLFSSL_LOCAL int  DoClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                              word32 helloSz);
+@@ -2125,17 +2126,18 @@ struct Suites {
+     byte   suites[WOLFSSL_MAX_SUITE_SZ];
+     byte   hashSigAlgo[WOLFSSL_MAX_SIGALGO]; /* sig/algo to offer */
+     byte   setSuites;               /* user set suites from default */
+-    byte   hashAlgo;                /* selected hash algorithm */
+-    byte   sigAlgo;                 /* selected sig algorithm */
+-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+-    WOLF_STACK_OF(WOLFSSL_CIPHER)* stack; /* stack of available cipher suites */
+-#endif
+ };
+ 
+ WOLFSSL_LOCAL void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
+                                          int haveRSAsig, int haveFalconSig,
+                                          int haveDilithiumSig, int haveAnon,
+                                          int tls1_2, int keySz);
++WOLFSSL_LOCAL void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig,
++                                            int haveRSAsig, int haveFalconSig,
++                                            int haveDilithiumSig, int haveAnon,
++                                            int tls1_2, int keySz, word16* len);
++WOLFSSL_LOCAL int AllocateCtxSuites(WOLFSSL_CTX* ctx);
++WOLFSSL_LOCAL int AllocateSuites(WOLFSSL* ssl);
+ WOLFSSL_LOCAL void InitSuites(Suites* suites, ProtocolVersion pv, int keySz,
+                               word16 haveRSA, word16 havePSK, word16 haveDH,
+                               word16 haveECDSAsig, word16 haveECC,
+@@ -2787,6 +2789,25 @@ WOLFSSL_API void wolfSSL_CTX_SetProcessPeerCertCb(WOLFSSL_CTX* ctx,
+        CallbackProcessPeerCert cb);
+ #endif /* DecodedCert && HAVE_PK_CALLBACKS */
+ 
++#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
++typedef struct SignatureAlgorithms {
++    /* Not const since it is modified in TLSX_SignatureAlgorithms_MapPss */
++    WOLFSSL*    ssl;
++    word16      hashSigAlgoSz; /* SigAlgo extension length in bytes */
++    /* Ignore "nonstandard extension used : zero-sized array in struct/union"
++     * MSVC warning */
++    #ifdef _MSC_VER
++    #pragma warning(disable: 4200)
++    #endif
++    byte        hashSigAlgo[]; /* sig/algo to offer */
++} SignatureAlgorithms;
++
++WOLFSSL_LOCAL SignatureAlgorithms* TLSX_SignatureAlgorithms_New(
++        WOLFSSL* ssl, word16 hashSigAlgoSz, void* heap);
++WOLFSSL_LOCAL void TLSX_SignatureAlgorithms_FreeAll(SignatureAlgorithms* sa,
++                                                    void* heap);
++#endif
++
+ /** Supported Elliptic Curves - RFC 4492 (session 4) */
+ #ifdef HAVE_SUPPORTED_CURVES
+ 
+@@ -4228,9 +4249,6 @@ typedef struct Options {
+         word16        dhKeyTested:1;      /* Set when key has been tested. */
+     #endif
+ #endif
+-#ifdef SINGLE_THREADED
+-    word16            ownSuites:1;        /* if suites are malloced in ssl object */
+-#endif
+ #ifdef HAVE_ENCRYPT_THEN_MAC
+     word16            disallowEncThenMac:1;   /* Don't do Encrypt-Then-MAC */
+     word16            encThenMac:1;           /* Doing Encrypt-Then-MAC */
+@@ -4255,6 +4273,8 @@ typedef struct Options {
+     byte            processReply;           /* nonblocking resume */
+     byte            cipherSuite0;           /* first byte, normally 0 */
+     byte            cipherSuite;            /* second byte, actual suite */
++    byte            hashAlgo;               /* selected hash algorithm */
++    byte            sigAlgo;                /* selected sig algorithm */
+     byte            serverState;
+     byte            clientState;
+     byte            handShakeState;
+@@ -4855,10 +4875,24 @@ typedef struct Dtls13Rtx {
+ typedef struct CIDInfo CIDInfo;
+ #endif /* WOLFSSL_DTLS_CID */
+ 
++/* The idea is to re-use the context suites object whenever possible to save
++ * space. */
++#define WOLFSSL_SUITES(ssl) \
++    ((const Suites*) ((ssl)->suites != NULL ? \
++        (ssl)->suites : \
++        (ssl)->ctx->suites))
++
+ /* wolfSSL ssl type */
+ struct WOLFSSL {
+     WOLFSSL_CTX*    ctx;
+-    Suites*         suites;             /* only need during handshake */
++    Suites*         suites; /* Only need during handshake. Can be NULL when
++                             * re-using the context's object. When WOLFSSL
++                             * object needs separate instance of suites use
++                             * AllocateSuites(). */
++#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
++    WOLF_STACK_OF(WOLFSSL_CIPHER)* suitesStack; /* stack of available cipher
++                                                 * suites */
++#endif
+     Arrays*         arrays;
+ #ifdef WOLFSSL_TLS13
+     byte            clientSecret[SECRET_LEN];
+@@ -4877,7 +4911,8 @@ struct WOLFSSL {
+     byte            dupSide;            /* write side or read side */
+ #endif
+ #ifdef OPENSSL_EXTRA
+-    byte              cbioFlag;  /* WOLFSSL_CBIO_RECV/SEND: CBIORecv/Send is set */
++    byte              cbioFlag;         /* WOLFSSL_CBIO_RECV/SEND:
++                                         * CBIORecv/Send is set */
+ #endif
+ #ifdef WOLFSSL_WOLFSENTRY_HOOKS
+     NetworkFilterCallback_t AcceptFilter;
+@@ -4907,7 +4942,8 @@ struct WOLFSSL {
+      * to encounter encryption blocking or fragment the message. */
+     struct WOLFSSL_ASYNC* async;
+ #endif
+-    void*           hsKey;              /* Handshake key (RsaKey or ecc_key) allocated from heap */
++    void*           hsKey;              /* Handshake key (RsaKey or ecc_key)
++                                         * allocated from heap */
+     word32          hsType;             /* Type of Handshake key (hsKey) */
+     WOLFSSL_CIPHER  cipher;
+ #ifndef WOLFSSL_AEAD_ONLY
+diff --git a/wolfssl/test.h b/wolfssl/test.h
+index 72105526e..aea9cd63f 100644
+--- a/wolfssl/test.h
++++ b/wolfssl/test.h
+@@ -5131,19 +5131,30 @@ void DEBUG_WRITE_DER(const byte* der, int derSz, const char* fileName);
+ 
+ #define DTLS_CID_BUFFER_SIZE 256
+ 
+-#if defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)       \
++#if !defined(NO_FILESYSTEM) && (                                               \
++    defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)       \
+     && defined(WOLFSSL_TLS13) &&                                               \
+     (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))\
+     ||                                                                         \
+     (defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                    \
+-     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER))
++     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER))               \
++    ||                                                                         \
++        (defined(HAVE_SECURE_RENEGOTIATION) &&                                 \
++            !defined(NO_RSA) &&                                                \
++            defined(HAVE_CHACHA) && defined(HAVE_POLY1305) &&                  \
++            defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256) &&             \
++            defined(HAVE_AESGCM))                                              \
++    )
++
+ #define TEST_MEMIO_BUF_SZ (64 * 1024)
+ struct test_memio_ctx
+ {
+     byte c_buff[TEST_MEMIO_BUF_SZ];
+     int c_len;
++    const char* c_ciphers;
+     byte s_buff[TEST_MEMIO_BUF_SZ];
+     int s_len;
++    const char* s_ciphers;
+ };
+ 
+ static WC_INLINE int test_memio_write_cb(WOLFSSL *ssl, char *data, int sz,
+@@ -5232,7 +5243,7 @@ static WC_INLINE int test_memio_do_handshake(WOLFSSL *ssl_c, WOLFSSL *ssl_s,
+                 hs_s = 1;
+             }
+             else {
+-                err = wolfSSL_get_error(ssl_c, ret);
++                err = wolfSSL_get_error(ssl_s, ret);
+                 if (err != WOLFSSL_ERROR_WANT_READ &&
+                     err != WOLFSSL_ERROR_WANT_WRITE)
+                     return -1;
+@@ -5256,37 +5267,58 @@ static WC_INLINE int test_memio_setup(struct test_memio_ctx *ctx,
+ {
+     int ret;
+ 
+-    *ctx_c = wolfSSL_CTX_new(method_c());
+-    *ctx_s = wolfSSL_CTX_new(method_s());
+-    if (*ctx_c == NULL || *ctx_s == NULL)
+-        return -1;
++    if (*ctx_c == NULL) {
++        *ctx_c = wolfSSL_CTX_new(method_c());
++        if (*ctx_c == NULL)
++            return -1;
++        ret = wolfSSL_CTX_load_verify_locations(*ctx_c, caCertFile, 0);
++        if (ret != WOLFSSL_SUCCESS)
++            return -1;
++        wolfSSL_SetIORecv(*ctx_c, test_memio_read_cb);
++        wolfSSL_SetIOSend(*ctx_c, test_memio_write_cb);
++        if (ctx->c_ciphers != NULL) {
++            ret = wolfSSL_CTX_set_cipher_list(*ctx_c, ctx->c_ciphers);
++            if (ret != WOLFSSL_SUCCESS)
++                return -1;
++        }
++    }
+ 
+-    ret = wolfSSL_CTX_use_PrivateKey_file(*ctx_s, svrKeyFile,
+-        WOLFSSL_FILETYPE_PEM);
+-    if (ret != WOLFSSL_SUCCESS)
+-        return- -1;
++    if (*ctx_s == NULL) {
++        *ctx_s = wolfSSL_CTX_new(method_s());
++        if (*ctx_s == NULL)
++            return -1;
++        ret = wolfSSL_CTX_use_PrivateKey_file(*ctx_s, svrKeyFile,
++            WOLFSSL_FILETYPE_PEM);
++        if (ret != WOLFSSL_SUCCESS)
++            return- -1;
++        ret = wolfSSL_CTX_use_certificate_file(*ctx_s, svrCertFile,
++                                               WOLFSSL_FILETYPE_PEM);
++        if (ret != WOLFSSL_SUCCESS)
++            return -1;
++        wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
++        wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
++        if (ctx->s_ciphers != NULL) {
++            ret = wolfSSL_CTX_set_cipher_list(*ctx_s, ctx->s_ciphers);
++            if (ret != WOLFSSL_SUCCESS)
++                return -1;
++        }
++    }
+ 
+-    ret = wolfSSL_CTX_use_certificate_file(*ctx_s, svrCertFile,
+-                                           WOLFSSL_FILETYPE_PEM);
+-    if (ret != WOLFSSL_SUCCESS)
+-        return -1;
+-    ret = wolfSSL_CTX_load_verify_locations(*ctx_c, caCertFile, 0);
+-    if (ret != WOLFSSL_SUCCESS)
+-        return -1;
+-    wolfSSL_SetIORecv(*ctx_c, test_memio_read_cb);
+-    wolfSSL_SetIOSend(*ctx_c, test_memio_write_cb);
+-    wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
+-    wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
+-
+-    *ssl_c = wolfSSL_new(*ctx_c);
+-    *ssl_s = wolfSSL_new(*ctx_s);
+-    if (*ssl_c == NULL || *ssl_s == NULL)
+-        return -1;
++    if (ssl_c != NULL) {
++        *ssl_c = wolfSSL_new(*ctx_c);
++        if (*ssl_c == NULL)
++            return -1;
++        wolfSSL_SetIOWriteCtx(*ssl_c, ctx);
++        wolfSSL_SetIOReadCtx(*ssl_c, ctx);
++    }
++    if (ssl_s != NULL) {
++        *ssl_s = wolfSSL_new(*ctx_s);
++        if (*ssl_s == NULL)
++            return -1;
++        wolfSSL_SetIOWriteCtx(*ssl_s, ctx);
++        wolfSSL_SetIOReadCtx(*ssl_s, ctx);
++    }
+ 
+-    wolfSSL_SetIOWriteCtx(*ssl_c, ctx);
+-    wolfSSL_SetIOReadCtx(*ssl_c, ctx);
+-    wolfSSL_SetIOWriteCtx(*ssl_s, ctx);
+-    wolfSSL_SetIOReadCtx(*ssl_s, ctx);
+     return 0;
+ }
+ #endif
+-- 
+2.39.1
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Workaround wolfSSL bug related to setting ciphers and secure renegotiation

## Motivation and Context
The current wolfSSL release has a bug when setting ciphers. Since there is no release with the fix we can simply use patches to work around the issue.

## How Has This Been Tested?
Tested using internal integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`