### PR TITLE
memory: expose the internal memory management api to public

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -464,6 +464,29 @@ he_return_code_t he_set_allocators(he_malloc_t malloc, he_calloc_t calloc, he_re
                                    he_free_t free);
 
 /**
+ * @brief Allocate memory using the internal malloc function set by he_set_allocators()
+ * @note The caller must call he_free when the allocated memory is no longer used
+ */
+void *he_malloc(size_t size);
+
+/**
+ * @brief Allocate memory using the internal calloc function set by he_set_allocators()
+ * @note The caller must call he_free when the allocated memory is no longer used
+ */
+void *he_calloc(size_t nmemb, size_t size);
+
+/**
+ * @brief Allocate memory using the internal realloc function set by he_set_allocators()
+ * @note The caller must call he_free when the allocated memory is no longer used
+ */
+void *he_realloc(void *ptr, size_t size);
+
+/**
+ * @brief Free memory using the internal free function set by he_set_allocators()
+ */
+void he_free(void *ptr);
+
+/**
  * @brief Initialises Helium global state
  * @return HE_SUCCESS Initialisation successful
  * @return HE_INIT_FAILED Fatal error - couldn't initialise global state

--- a/src/he/client.c
+++ b/src/he/client.c
@@ -26,7 +26,7 @@
 #include "memory.h"
 
 he_client_t *he_client_create() {
-  he_client_t *client = he_internal_calloc(1, sizeof(he_client_t));
+  he_client_t *client = he_calloc(1, sizeof(he_client_t));
   if(!client) {
     return NULL;
   }
@@ -51,7 +51,7 @@ he_return_code_t he_client_destroy(he_client_t *client) {
     he_plugin_destroy_chain(client->outside_plugins);
 
     // Should be safe to free now
-    he_internal_free(client);
+    he_free(client);
   }
   return HE_SUCCESS;
 }

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -138,13 +138,13 @@ he_return_code_t he_conn_set_sni_hostname(he_conn_t *conn, const char *hostname)
 }
 
 he_conn_t *he_conn_create() {
-  return he_internal_calloc(1, sizeof(he_conn_t));
+  return he_calloc(1, sizeof(he_conn_t));
 }
 
 void he_conn_destroy(he_conn_t *conn) {
   if(conn) {
     wolfSSL_free(conn->wolf_ssl);
-    he_internal_free(conn);
+    he_free(conn);
   }
 }
 

--- a/src/he/memory.c
+++ b/src/he/memory.c
@@ -42,14 +42,14 @@ he_return_code_t he_set_allocators(he_malloc_t new_malloc, he_calloc_t new_callo
   return HE_SUCCESS;
 }
 
-void *he_internal_malloc(size_t size) {
+void *he_malloc(size_t size) {
   if(internal_malloc) {
     return internal_malloc(size);
   } else {
     return malloc(size);
   }
 }
-void *he_internal_calloc(size_t nmemb, size_t size) {
+void *he_calloc(size_t nmemb, size_t size) {
   if(internal_calloc) {
     return internal_calloc(nmemb, size);
   } else {
@@ -57,7 +57,7 @@ void *he_internal_calloc(size_t nmemb, size_t size) {
   }
 }
 
-void *he_internal_realloc(void *ptr, size_t size) {
+void *he_realloc(void *ptr, size_t size) {
   if(internal_realloc) {
     return internal_realloc(ptr, size);
   } else {
@@ -65,7 +65,7 @@ void *he_internal_realloc(void *ptr, size_t size) {
   }
 }
 
-void he_internal_free(void *ptr) {
+void he_free(void *ptr) {
   if(internal_free) {
     internal_free(ptr);
   } else {

--- a/src/he/memory.h
+++ b/src/he/memory.h
@@ -41,9 +41,27 @@
 he_return_code_t he_set_allocators(he_malloc_t malloc, he_calloc_t calloc, he_realloc_t realloc,
                                    he_free_t free);
 
-void *he_internal_malloc(size_t size);
-void *he_internal_calloc(size_t nmemb, size_t size);
-void *he_internal_realloc(void *ptr, size_t size);
-void he_internal_free(void *ptr);
+/**
+ * @brief Allocate memory using the internal malloc function set by he_set_allocators()
+ * @note The caller must call he_free when the allocated memory is no longer used
+ */
+void *he_malloc(size_t size);
+
+/**
+ * @brief Allocate memory using the internal calloc function set by he_set_allocators()
+ * @note The caller must call he_free when the allocated memory is no longer used
+ */
+void *he_calloc(size_t nmemb, size_t size);
+
+/**
+ * @brief Allocate memory using the internal realloc function set by he_set_allocators()
+ * @note The caller must call he_free when the allocated memory is no longer used
+ */
+void *he_realloc(void *ptr, size_t size);
+
+/**
+ * @brief Free memory using the internal free function set by he_set_allocators()
+ */
+void he_free(void *ptr);
 
 #endif  // MEMORY_H

--- a/src/he/plugin_chain.c
+++ b/src/he/plugin_chain.c
@@ -21,13 +21,13 @@
 #include "memory.h"
 
 he_plugin_chain_t *he_plugin_create_chain(void) {
-  return he_internal_calloc(1, sizeof(he_plugin_chain_t));
+  return he_calloc(1, sizeof(he_plugin_chain_t));
 }
 
 void he_plugin_destroy_chain(he_plugin_chain_t *chain) {
   if (chain) {
     he_plugin_destroy_chain(chain->next);
-    he_internal_free(chain);
+    he_free(chain);
   }
 }
 

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -109,13 +109,13 @@ he_return_code_t he_ssl_ctx_is_valid_server(he_ssl_ctx_t *ctx) {
 }
 
 he_ssl_ctx_t *he_ssl_ctx_create() {
-  return he_internal_calloc(1, sizeof(he_ssl_ctx_t));
+  return he_calloc(1, sizeof(he_ssl_ctx_t));
 }
 
 void he_ssl_ctx_destroy(he_ssl_ctx_t *ctx) {
   if(ctx) {
     wolfSSL_CTX_free(ctx->wolf_ctx);
-    he_internal_free(ctx);
+    he_free(ctx);
   }
 }
 

--- a/test/he/test_client.c
+++ b/test/he/test_client.c
@@ -45,7 +45,7 @@ void tearDown(void) {
 }
 
 void test_client_create_fails_initial_calloc(void) {
-  he_internal_calloc_ExpectAnyArgsAndReturn(NULL);
+  he_calloc_ExpectAnyArgsAndReturn(NULL);
   he_client_t *test_client = he_client_create();
 
   TEST_ASSERT_NULL(test_client);
@@ -54,7 +54,7 @@ void test_client_create_fails_initial_calloc(void) {
 void setup_create_expectations(he_ssl_ctx_t *ctx1, he_conn_t *conn1,
                                he_plugin_chain_t *inside_plugins1,
                                he_plugin_chain_t *outside_plugins1) {
-  he_internal_calloc_ExpectAnyArgsAndReturn(client);
+  he_calloc_ExpectAnyArgsAndReturn(client);
 
   he_ssl_ctx_create_ExpectAndReturn(ctx1);
   he_conn_create_ExpectAndReturn(conn1);
@@ -66,7 +66,7 @@ void setup_create_expectations(he_ssl_ctx_t *ctx1, he_conn_t *conn1,
     he_ssl_ctx_destroy_ExpectAnyArgs();
     he_plugin_destroy_chain_ExpectAnyArgs();
     he_plugin_destroy_chain_ExpectAnyArgs();
-    he_internal_free_ExpectAnyArgs();
+    he_free_ExpectAnyArgs();
   }
 }
 
@@ -111,7 +111,7 @@ void test_client_destroy_destroys_it_all(void) {
   he_ssl_ctx_destroy_Expect(&ssl_ctx);
   he_plugin_destroy_chain_Expect(&inside_plugins);
   he_plugin_destroy_chain_Expect(&outside_plugins);
-  he_internal_free_Expect(client);
+  he_free_Expect(client);
 
   he_client_destroy(client);
 }

--- a/test/he/test_memory.c
+++ b/test/he/test_memory.c
@@ -59,36 +59,36 @@ void free_for_test(void *ptr) {
 }
 
 void test_default_malloc_calloc_free(void) {
-  int *malloced = he_internal_malloc(sizeof(int));
+  int *malloced = he_malloc(sizeof(int));
   TEST_ASSERT_NOT_NULL(malloced);
 
-  int *calloced = he_internal_calloc(1, sizeof(int));
+  int *calloced = he_calloc(1, sizeof(int));
   TEST_ASSERT_NOT_NULL(calloced);
   TEST_ASSERT_EQUAL(0, *calloced);
 
-  calloced = he_internal_realloc(calloced, 2 * sizeof(int));
+  calloced = he_realloc(calloced, 2 * sizeof(int));
   TEST_ASSERT_NOT_NULL(calloced);
   TEST_ASSERT_EQUAL(0, *calloced);
 
-  he_internal_free(malloced);
-  he_internal_free(calloced);
+  he_free(malloced);
+  he_free(calloced);
 }
 
 void test_custom_malloc_calloc_free(void) {
   he_set_allocators(malloc_for_test, calloc_for_test, realloc_for_test, free_for_test);
 
-  int *malloced = he_internal_malloc(sizeof(int));
+  int *malloced = he_malloc(sizeof(int));
   TEST_ASSERT_NULL(malloced);
   TEST_ASSERT_EQUAL(1, malloc_calls);
 
-  int *calloced = he_internal_calloc(1, sizeof(int));
+  int *calloced = he_calloc(1, sizeof(int));
   TEST_ASSERT_NULL(calloced);
   TEST_ASSERT_EQUAL(1, calloc_calls);
 
-  calloced = he_internal_realloc(calloced, sizeof(int));
+  calloced = he_realloc(calloced, sizeof(int));
   TEST_ASSERT_NULL(calloced);
   TEST_ASSERT_EQUAL(1, realloc_calls);
 
-  he_internal_free(malloced);
+  he_free(malloced);
   TEST_ASSERT_EQUAL(1, free_calls);
 }

--- a/test/he/test_plugin_chain.c
+++ b/test/he/test_plugin_chain.c
@@ -153,7 +153,7 @@ void test_multiple_plugins(void) {
   res = he_plugin_register_plugin(&chain, &call_counting_plugin);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);
 
-  he_internal_calloc_ExpectAndReturn(1, sizeof(he_plugin_chain_t), &chain_sibling);
+  he_calloc_ExpectAndReturn(1, sizeof(he_plugin_chain_t), &chain_sibling);
   res = he_plugin_register_plugin(&chain, &call_counting_plugin);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);
 
@@ -181,7 +181,7 @@ void test_ingress_egress_opposite_order(void) {
   // whereas we would expect egress to return "drop",
   // since we zero out the packet before running the zero-dropping plugin.
 
-  he_internal_calloc_ExpectAndReturn(1, sizeof(he_plugin_chain_t), &chain_sibling);
+  he_calloc_ExpectAndReturn(1, sizeof(he_plugin_chain_t), &chain_sibling);
   res = he_plugin_register_plugin(&chain, &wipeout_plugin);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);
 
@@ -250,7 +250,7 @@ void test_plugin_destroy_chain_null(void) {
 
 void test_plugin_destroy_chain_single(void) {
   he_plugin_chain_t chain = {0};
-  he_internal_free_Expect(&chain);
+  he_free_Expect(&chain);
   he_plugin_destroy_chain(&chain);
 }
 
@@ -259,7 +259,7 @@ void test_plugin_destroy_chain_multiple_plugins(void) {
   he_plugin_chain_t chain = {
       .next = &sibling,
   };
-  he_internal_free_Expect(&sibling);
-  he_internal_free_Expect(&chain);
+  he_free_Expect(&sibling);
+  he_free_Expect(&chain);
   he_plugin_destroy_chain(&chain);
 }


### PR DESCRIPTION
## Description
Make the internal memory management api public.

## Motivation and Context
Allow all downstream components using the same memory functions set by the `he_set_allocators`.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`