### PR TITLE
earthly: fix architecture to amd64

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.6
-FROM debian:bullseye-slim
+FROM --platform=linux/amd64 debian:bullseye-slim
 WORKDIR /libhelium
 
 debian-deps:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix earthly arch to amd64

## Motivation and Context
We can't use arm64 because cmock seems to have issues when generating mocks for wolfSSL on arm.
This allows an m1 user to use earthly.

## How Has This Been Tested?
Tested locally on an m1 macbook

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`