### PR TITLE
build: set target and host for macos x86

### DIFF
--- a/macos.yml
+++ b/macos.yml
@@ -15,13 +15,13 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256
+        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -target x86_64-apple-macos10.12
         - CC=clang
       :build:
         - git apply ../../wolfssl/0001-Merge-pull-request-5911-from-julek-wolfssl-DtlsMsgPo.patch
         - git apply ../../wolfssl/0001-Merge-pull-request-5932-from-julek-wolfssl-zd15346.patch
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
+        - "./configure --host=x86_64-apple-darwin --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"
         - "make install"
       :artifacts:
@@ -30,6 +30,12 @@
           - include/wolfssl # needed e.g. for mock_ssl.h to find wolfssl/ssl.h
         :static_libraries:
           - lib/libwolfssl.a
+
+:flags:
+  :release:
+    :compile:
+      :*:
+        - -target x86_64-apple-macos10.12
 
 :environment:
   - MACOSX_DEPLOYMENT_TARGET: "10.10"


### PR DESCRIPTION

## Description
set target and host for macos x86

## Motivation and Context
This allows the library to be cross compiled from m1

## How Has This Been Tested?
Tested by manually compiling on an m1 mac

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`