### PR TITLE
ci: Fix linux-386 CI and run CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Install Ceedling
         run: sudo gem install ceedling --no-user-install
       - name: Install gcc multi lib
-        run: sudo apt install -y gcc-multilib
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-multilib
       - name: Build dependencies
         run: ceedling project:linux_386 clobber dependencies:make
       - name: Run wolfSSL Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches:
+      - '**'
   pull_request:
     branches: [main]
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CI update to fix linux-386 CI and add CI to all branches so developers can test CI changes easily without opening a PR

## Motivation and Context
CI is currently broken

## How Has This Been Tested?
Change is to CI so CI tests this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`