### PR TITLE
wolfssl: update wolfssl to v5.6.2-stable

### DIFF
--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
+        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_ATOMICS
       :build:
         - "autoreconf -i"
         - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"

--- a/unix.yml
+++ b/unix.yml
@@ -16,7 +16,7 @@
 
 :environment:
   - :he_wolfssl_source: https://github.com/wolfSSL/wolfssl
-  - :he_wolfssl_commit: v5.6.0-stable
+  - :he_wolfssl_commit: v5.6.2-stable
 
 :tools_test_file_preprocessor:
   :arguments:

--- a/windows_32.yml
+++ b/windows_32.yml
@@ -50,7 +50,7 @@
       :fetch:
         :method: :git
         :source: https://github.com/wolfSSL/wolfssl.git
-        :hash: v5.6.0-stable
+        :hash: v5.6.2-stable
       :build:
         - "cp ../../windows/wolfssl-user_settings-32.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-32.h IDE/WIN/user_settings.h"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -50,7 +50,7 @@
       :fetch:
         :method: :git
         :source: https://github.com/wolfSSL/wolfssl.git
-        :hash: v5.6.0-stable
+        :hash: v5.6.2-stable
       :build:
         - "cp ../../windows/wolfssl-user_settings-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-64.h IDE/WIN/user_settings.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update WolfSSL v5.6.2-stable. Changes: https://github.com/wolfSSL/wolfssl/releases/tag/v5.6.2-stable

## Motivation and Context
Keeping Lightway dependencies up-to-date.

## How Has This Been Tested?
Tested on Github Actions.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`