### PR TITLE
Add support for open quantum safe algorithms

### DIFF
--- a/3rd_party_deps.yml
+++ b/3rd_party_deps.yml
@@ -1,0 +1,26 @@
+--- # ceedling project file for 3rd party dependencies
+
+# Build instructions for liboqs taken from:
+# https://github.com/wolfSSL/wolfssl/blob/106a065a41f283d7603cda824d857d308287da3b/INSTALL#L139
+# https://www.wolfssl.com/documentation/manuals/wolfssl/appendix07.html
+
+:dependencies:
+  :libraries:
+    - :name: liboqs
+      :source_path: third_party/liboqs
+      :fetch:
+        :method: :git
+        :source: https://github.com/open-quantum-safe/liboqs
+        :hash: af76ca3b1f2fbc1f4f0967595f3bb07692fb3d82
+      :build:
+        - "mkdir -p build"
+        - "cd build && cmake -DOQS_BUILD_ONLY_LIB=ON -DOQS_USE_OPENSSL=OFF .." # For now build all algorithms
+        - "cd build && make all"
+        - "cd build && make install"
+      :artifacts:
+        :includes:
+          - include
+          - include/oqs
+        :static_libraries:
+          - lib/liboqs.a
+

--- a/3rd_party_deps.yml
+++ b/3rd_party_deps.yml
@@ -11,7 +11,7 @@
       :fetch:
         :method: :git
         :source: https://github.com/open-quantum-safe/liboqs
-        :tag: 0.8.0
+        :hash: af76ca3b1f2fbc1f4f0967595f3bb07692fb3d82
       :build:
         - "mkdir -p build"
         - "cd build && cmake -DOQS_BUILD_ONLY_LIB=ON -DOQS_USE_OPENSSL=OFF .." # For now build all algorithms

--- a/3rd_party_deps.yml
+++ b/3rd_party_deps.yml
@@ -11,10 +11,13 @@
       :fetch:
         :method: :git
         :source: https://github.com/open-quantum-safe/liboqs
-        :hash: af76ca3b1f2fbc1f4f0967595f3bb07692fb3d82
+        :tag: 0.8.0
+      :environment:
+        - CFLAGS= -Os
       :build:
+        # Build the library only, do not use OpenSSL, Set algorithms to support WolfSSL's "WOLFSSL_P521_KYBER_LEVEL5", disable all other unnecessary algorithms.
         - "mkdir -p build"
-        - "cd build && cmake -DOQS_BUILD_ONLY_LIB=ON -DOQS_USE_OPENSSL=OFF .." # For now build all algorithms
+        - "cd build && cmake -DCMAKE_INSTALL_PREFIX=/usr -DOQS_BUILD_ONLY_LIB=ON -DOQS_USE_OPENSSL=OFF -DOQS_MINIMAL_BUILD='KEM_kyber_512;KEM_kyber_768;KEM_kyber_1024;SIG_dilithium_2;SIG_dilithium_3;SIG_dilithium_5;SIG_falcon_512;SIG_falcon_1024' .."
         - "cd build && make all"
         - "cd build && make install"
       :artifacts:

--- a/3rd_party_deps.yml
+++ b/3rd_party_deps.yml
@@ -11,7 +11,7 @@
       :fetch:
         :method: :git
         :source: https://github.com/open-quantum-safe/liboqs
-        :hash: af76ca3b1f2fbc1f4f0967595f3bb07692fb3d82
+        :tag: 0.8.0
       :build:
         - "mkdir -p build"
         - "cd build && cmake -DOQS_BUILD_ONLY_LIB=ON -DOQS_USE_OPENSSL=OFF .." # For now build all algorithms

--- a/3rd_party_deps.yml
+++ b/3rd_party_deps.yml
@@ -13,6 +13,7 @@
         :source: https://github.com/open-quantum-safe/liboqs
         :tag: 0.8.0
       :environment:
+        # CFLAGS taken from: https://www.wolfssl.com/documentation/manuals/wolfssl/appendix07.html
         - CFLAGS= -Os
       :build:
         # Build the library only, do not use OpenSSL, Set algorithms to support WolfSSL's "WOLFSSL_P521_KYBER_LEVEL5", disable all other unnecessary algorithms.

--- a/Earthfile
+++ b/Earthfile
@@ -17,8 +17,10 @@ libhelium-deps:
     # Make the directory structure so that the config can be parsed
     # To improve caching we want to separate this out as the WolfSSL dependency
     # fetch and build are the slowest parts of the process.
-    RUN mkdir -p src include test/support third_party/wolfssl
-    # Build and fetch the dependencies
+    RUN mkdir -p src include test/support third_party/wolfssl third_party/liboqs
+    # Build and fetch 3rd party dependencies
+    RUN ceedling dependencies:make project:3rd_party_deps
+    # Build and fetch WolfSSL for Linux
     RUN ceedling dependencies:make project:linux
 
 build:

--- a/linux.yml
+++ b/linux.yml
@@ -18,7 +18,7 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
+        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni --with-liboqs"
         - "make"
         - "make install"
       :artifacts:

--- a/linux.yml
+++ b/linux.yml
@@ -15,7 +15,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :hash: $HE_WOLFSSL_COMMIT
       :environment:
-        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
+        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_SPHINCS
       :build:
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni --disable-crypttests --with-liboqs"

--- a/linux.yml
+++ b/linux.yml
@@ -18,7 +18,7 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
         - "autoreconf -i"
-        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni --with-liboqs"
+        - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni --disable-crypttests --with-liboqs"
         - "make"
         - "make install"
       :artifacts:


### PR DESCRIPTION
## Description

**Overview.**
Add support for Post-Quantum Cryptography via Open Quantum Safe's `liboqs`.

**Details:**

Ceedling:
Add a Ceedling task to build 3rd party dependencies. `3rd_party_deps.yml`
This YAML task currently builds `liboqs` but can be used to build other common/shared 3rd party:dependencies.

Liboqs:
We currently build `iboqs` with a reduced selection of signature algorithm and KEMs. 
Allowing us to be more selective and to be able to react to any situations where issues may be found with algorithm or KEMs.

WolfSSL:
Enable liboqs build flag for WolfSSL for the Linux build. `linux.yml`
This requires us to set the `CFLAGS` option `-DWOLFSSL_NO_SPHINCS`.

Earthly:
Update the `Earthfile` to support the changes.

**Upstream dependencies:**
This PR depends on a WolfSSL PR (Add in -DWOLFSSL_NO_SPHINCS):
https://github.com/wolfSSL/wolfssl/pull/6715

**References:**
https://www.wolfssl.com/documentation/manuals/wolfssl/appendix07.html
https://github.com/wolfSSL/wolfssl/blob/106a065a41f283d7603cda824d857d308287da3b/INSTALL#L139

## Motivation and Context
Lightway can defend against active Save Now, Decrypt Later attacks.

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`