### PR TITLE
wolfssl: add patches for dtls downgrade bugs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -18,6 +18,8 @@ libhelium-deps:
     # To improve caching we want to separate this out as the WolfSSL dependency
     # fetch and build are the slowest parts of the process.
     RUN mkdir -p src include test/support third_party/wolfssl
+    # Copy the patch files
+    COPY --dir wolfssl ./
     # Build and fetch the dependencies
     RUN ceedling dependencies:make project:linux
 

--- a/android.yml
+++ b/android.yml
@@ -18,6 +18,9 @@
         - C_EXTRA_FLAGS= -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -fomit-frame-pointer
         - LIBS=-llog -landroid
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - autoreconf -i
         - ./configure $CROSS_OPTS C_EXTRA_FLAGS="$C_EXTRA_FLAGS" --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni
         - make

--- a/ios.yml
+++ b/ios.yml
@@ -17,6 +17,10 @@
       :environment:
         - MACOSX_DEPLOYMENT_TARGET=10.0
       :build:
+        # For some reason this attempts to run twice as a result the git apply will fail the second time
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch || true
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch || true
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch || true
         - autoreconf -i
         - "cp ../../ios/autotools-ios-helper.sh ./autotools-ios-helper.sh"
         - "./autotools-ios-helper.sh"

--- a/linux.yml
+++ b/linux.yml
@@ -17,6 +17,9 @@
       :environment:
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/linux_386.yml
+++ b/linux_386.yml
@@ -18,6 +18,9 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -m32 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256
         - LDFLAGS= -m32
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "autoreconf -i"
         - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -17,6 +17,9 @@
       :environment:
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_ATOMICS
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "autoreconf -i"
         - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/macos.yml
+++ b/macos.yml
@@ -18,6 +18,9 @@
         - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -target x86_64-apple-macos10.12
         - CC=clang
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "autoreconf -i"
         - "./configure --host=x86_64-apple-darwin --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --enable-secure-renegotiation --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -19,6 +19,9 @@
         - CC=clang
         - MACOSX_DEPLOYMENT_TARGET=10.10
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "autoreconf -i"
         - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-secure-renegotiation --enable-armasm --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/tvos.yml
+++ b/tvos.yml
@@ -17,6 +17,10 @@
       :environment:
         - MACOSX_DEPLOYMENT_TARGET=10.0
       :build:
+        # For some reason this attempts to run twice as a result the git apply will fail the second time
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch || true
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch || true
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch || true
         - autoreconf -i
         - cp ../../ios/autotools-ios-helper.sh ./autotools-ios-helper.sh
         - PREFIX=$(pwd)/../builds/wolfssl_tvos ./autotools-ios-helper.sh

--- a/windows_32.yml
+++ b/windows_32.yml
@@ -52,6 +52,9 @@
         :source: https://github.com/wolfSSL/wolfssl.git
         :hash: v5.6.3-stable
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "cp ../../windows/wolfssl-user_settings-32.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-32.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -52,6 +52,9 @@
         :source: https://github.com/wolfSSL/wolfssl.git
         :hash: v5.6.3-stable
       :build:
+        - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+        - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+        - git apply ../../wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - "cp ../../windows/wolfssl-user_settings-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-64.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+++ b/wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
@@ -1,0 +1,30 @@
+From fee5f9edc7d2e36cf8cbcbbb5d8e992e895af289 Mon Sep 17 00:00:00 2001
+From: Juliusz Sosinowicz <juliusz@wolfssl.com>
+Date: Fri, 28 Jul 2023 22:22:08 +0200
+Subject: [PATCH 1/2] DoHelloVerifyRequest: only do DTLS 1.3 version check
+
+---
+ src/internal.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/internal.c b/src/internal.c
+index ca166e8d9..37c267e37 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -26653,9 +26653,11 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
+ #if defined(WOLFSSL_DTLS13) && defined(WOLFSSL_TLS13)
+         if (IsAtLeastTLSv1_3(ssl->version) && ssl->options.dtls) {
+             /* we sent a TLSv1.3 ClientHello but received a
+-             * HELLO_VERIFY_REQUEST */
++             * HELLO_VERIFY_REQUEST. We only check if DTLSv1_3_MINOR is the
++             * min downgrade option as per the server_version field comments in
++             * https://www.rfc-editor.org/rfc/rfc6347#section-4.2.1 */
+             if (!ssl->options.downgrade ||
+-                    ssl->options.minDowngrade < pv.minor)
++                    ssl->options.minDowngrade <= DTLSv1_3_MINOR)
+                 return VERSION_ERROR;
+         }
+ #endif /* defined(WOLFSSL_DTLS13) && defined(WOLFSSL_TLS13) */
+-- 
+2.41.0
+

--- a/wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
+++ b/wolfssl/0001-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
@@ -1,0 +1,26 @@
+From 438e81ff3effa4088a9c67ff7670494df3234dfa Mon Sep 17 00:00:00 2001
+From: Juliusz Sosinowicz <juliusz@wolfssl.com>
+Date: Mon, 31 Jul 2023 13:20:52 +0200
+Subject: [PATCH] DtlsShouldDrop: don't ignore app data sent before a SCR
+ handshake
+
+---
+ src/internal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/internal.c b/src/internal.c
+index 37c267e37..f61c1d7c8 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -19148,7 +19148,7 @@ static int DtlsShouldDrop(WOLFSSL* ssl, int retcode)
+ 
+ #ifndef NO_WOLFSSL_SERVER
+     if (ssl->options.side == WOLFSSL_SERVER_END
+-            && ssl->curRL.type != handshake) {
++            && ssl->curRL.type != handshake && !IsSCR(ssl)) {
+         int beforeCookieVerified = 0;
+         if (!IsAtLeastTLSv1_3(ssl->version)) {
+             beforeCookieVerified =
+-- 
+2.41.0
+

--- a/wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+++ b/wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
@@ -1,0 +1,39 @@
+From 3dd975ad308872e34aa73848a2d1dbaee2b2c970 Mon Sep 17 00:00:00 2001
+From: Juliusz Sosinowicz <juliusz@wolfssl.com>
+Date: Thu, 3 Aug 2023 14:59:21 +0200
+Subject: [PATCH 2/2] DTLS 1.3: move state machine forward when HVR received
+
+---
+ src/tls13.c | 2 +-
+ tests/api.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/tls13.c b/src/tls13.c
+index 4726c8322..d7b0f17c9 100644
+--- a/src/tls13.c
++++ b/src/tls13.c
+@@ -11623,7 +11623,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
+         case CLIENT_HELLO_SENT:
+             /* Get the response/s from the server. */
+             while (ssl->options.serverState <
+-                                          SERVER_HELLO_RETRY_REQUEST_COMPLETE) {
++                    SERVER_HELLOVERIFYREQUEST_COMPLETE) {
+                 if ((ssl->error = ProcessReply(ssl)) < 0) {
+                         WOLFSSL_ERROR(ssl->error);
+                         return WOLFSSL_FATAL_ERROR;
+diff --git a/tests/api.c b/tests/api.c
+index 73b0dd00a..f705fc3b9 100644
+--- a/tests/api.c
++++ b/tests/api.c
+@@ -6510,7 +6510,7 @@ static int test_client_nofail(void* args, cbType cb)
+             if (ret < 0) { break; } else if (ret == 0) { continue; }
+         }
+     #endif
+-        ret = wolfSSL_connect(ssl);
++        ret = wolfSSL_negotiate(ssl);
+         err = wolfSSL_get_error(ssl, 0);
+     } while (err == WC_PENDING_E);
+     if (ret != WOLFSSL_SUCCESS) {
+-- 
+2.41.0
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add patches that are in wolfSSL master but not in a tagged release. Fixes a some dtls downgrade bugs.

## Motivation and Context
This fixes a case where DTLS1.3 client will not downgrade to DTLS1.2 when attempting to connect to a DTLS1.2 server

## How Has This Been Tested?
Tested together with #76 on lightway-laser

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`