### PR TITLE
wolfssl: add new dtls 1.3 ack patch

### DIFF
--- a/android.yml
+++ b/android.yml
@@ -22,6 +22,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - autoreconf -i
         - ./configure $CROSS_OPTS C_EXTRA_FLAGS="$C_EXTRA_FLAGS" --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-secure-renegotiation --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --disable-examples --disable-sys-ca-certs --enable-sni
         - make

--- a/ios.yml
+++ b/ios.yml
@@ -22,6 +22,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch || true
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch || true
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch || true
+          - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch || true
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch || true
         - autoreconf -i
         - "cp ../../ios/autotools-ios-helper.sh ./autotools-ios-helper.sh"
         - "./autotools-ios-helper.sh"

--- a/linux.yml
+++ b/linux.yml
@@ -21,6 +21,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "autoreconf -i"
         - "./configure --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-secure-renegotiation --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/linux_386.yml
+++ b/linux_386.yml
@@ -22,6 +22,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "autoreconf -i"
         - "./configure --disable-asm --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-secure-renegotiation --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/linux_arm.yml
+++ b/linux_arm.yml
@@ -21,6 +21,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "autoreconf -i"
         - "./configure --host=$CROSS_COMPILE --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-secure-renegotiation --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-chacha --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/macos.yml
+++ b/macos.yml
@@ -22,6 +22,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "autoreconf -i"
         - "./configure --host=x86_64-apple-darwin --enable-tls13 --disable-oldtls --enable-aesni --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-secure-renegotiation --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --enable-intelasm --disable-dh --enable-curve25519 --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -23,6 +23,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "autoreconf -i"
         - "./configure --host=aarch64-apple-darwin --enable-tls13 --disable-oldtls --prefix=$(pwd)/../builds/wolfssl_build --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-secure-renegotiation --enable-sp=yes,4096 --enable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --disable-shared --enable-curve25519 --enable-armasm --disable-examples --disable-sys-ca-certs --enable-sni"
         - "make"

--- a/tvos.yml
+++ b/tvos.yml
@@ -22,6 +22,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch || true
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch || true
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch || true
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch || true
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch || true
         - autoreconf -i
         - cp ../../ios/autotools-ios-helper.sh ./autotools-ios-helper.sh
         - PREFIX=$(pwd)/../builds/wolfssl_tvos ./autotools-ios-helper.sh

--- a/windows_32.yml
+++ b/windows_32.yml
@@ -56,6 +56,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "cp ../../windows/wolfssl-user_settings-32.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-32.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -56,6 +56,8 @@
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
         - git apply ../../wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
         - git apply ../../wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+        - git apply ../../wolfssl/2000-Rename-utils.c-to-utils.h.patch
+        - git apply ../../wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
         - "cp ../../windows/wolfssl-user_settings-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-64.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
+++ b/wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
@@ -1,7 +1,7 @@
 From fee5f9edc7d2e36cf8cbcbbb5d8e992e895af289 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Fri, 28 Jul 2023 22:22:08 +0200
-Subject: [PATCH 1/4] DoHelloVerifyRequest: only do DTLS 1.3 version check
+Subject: [PATCH 1/5] DoHelloVerifyRequest: only do DTLS 1.3 version check
 
 ---
  src/internal.c | 6 ++++--

--- a/wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
+++ b/wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch
@@ -1,7 +1,7 @@
 From 3dd975ad308872e34aa73848a2d1dbaee2b2c970 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Thu, 3 Aug 2023 14:59:21 +0200
-Subject: [PATCH 2/4] DTLS 1.3: move state machine forward when HVR received
+Subject: [PATCH 2/5] DTLS 1.3: move state machine forward when HVR received
 
 ---
  src/tls13.c | 2 +-

--- a/wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
+++ b/wolfssl/0003-DtlsShouldDrop-don-t-ignore-app-data-sent-before-a-S.patch
@@ -1,7 +1,7 @@
 From 438e81ff3effa4088a9c67ff7670494df3234dfa Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Mon, 31 Jul 2023 13:20:52 +0200
-Subject: [PATCH 3/4] DtlsShouldDrop: don't ignore app data sent before a SCR
+Subject: [PATCH 3/5] DtlsShouldDrop: don't ignore app data sent before a SCR
  handshake
 
 ---

--- a/wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
+++ b/wolfssl/0004-Dtls13GetRnMask-Correctly-get-chacha-counter-on-BE-s.patch
@@ -1,7 +1,7 @@
 From 0143469120bd470fddbea8fc092c292c5e17d0d0 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Fri, 21 Jul 2023 14:48:28 +0200
-Subject: [PATCH 4/4] Dtls13GetRnMask: Correctly get chacha counter on BE
+Subject: [PATCH 4/5] Dtls13GetRnMask: Correctly get chacha counter on BE
  systems
 
 The issue was that BIG_ENDIAN is defined in endian.h (on linux). Our define is BIG_ENDIAN_ORDER.

--- a/wolfssl/2000-Rename-utils.c-to-utils.h.patch
+++ b/wolfssl/2000-Rename-utils.c-to-utils.h.patch
@@ -1,0 +1,426 @@
+From ec68b6baf87ffde6030d10d1b9ea400df6122285 Mon Sep 17 00:00:00 2001
+From: Juliusz Sosinowicz <juliusz@wolfssl.com>
+Date: Fri, 18 Aug 2023 15:05:23 +0200
+Subject: [PATCH 1/2] Rename utils.c to utils.h
+
+This better signals that this file is meant to be included directly in testing programs and also plays better with my IDE.
+
+(cherry picked from commit b32ff0b0b8f5d34bc827203c481509cdec6b0356)
+---
+ tests/api.c           |   2 +
+ tests/include.am      |   3 +-
+ tests/utils.h         | 361 ++++++++++++++++++++++++++++++++++++++++++
+ testsuite/testsuite.c |   4 +
+ 4 files changed, 369 insertions(+), 1 deletion(-)
+ create mode 100644 tests/utils.h
+
+diff --git a/tests/api.c b/tests/api.c
+index f705fc3b9..9d5d1933e 100644
+--- a/tests/api.c
++++ b/tests/api.c
+@@ -358,6 +358,8 @@
+ #endif
+ #include <wolfssl/certs_test.h>
+ 
++#include "tests/utils.h"
++
+ #ifndef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
+     /* FIPS build has replaced ecc.h. */
+     #define wc_ecc_key_get_priv(key) (&((key)->k))
+diff --git a/tests/include.am b/tests/include.am
+index 54c40f635..df969764a 100644
+--- a/tests/include.am
++++ b/tests/include.am
+@@ -68,5 +68,6 @@ EXTRA_DIST += tests/unit.h \
+               tests/test-ecc-cust-curves.conf \
+               tests/NCONF_test.cnf \
+               tests/test-tls-downgrade.conf \
+-              tests/TXT_DB.txt
++              tests/TXT_DB.txt \
++              tests/utils.h
+ DISTCLEANFILES+= tests/.libs/unit.test
+diff --git a/tests/utils.h b/tests/utils.h
+new file mode 100644
+index 000000000..e50615d72
+--- /dev/null
++++ b/tests/utils.h
+@@ -0,0 +1,361 @@
++/* utils.h
++ *
++ * Copyright (C) 2006-2023 wolfSSL Inc.
++ *
++ * This file is part of wolfSSL.
++ *
++ * wolfSSL is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * wolfSSL is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
++ */
++#ifdef HAVE_CONFIG_H
++    #include <config.h>
++#endif
++
++#include <wolfssl/wolfcrypt/settings.h>
++#include <tests/unit.h>
++
++#ifndef NO_FILESYSTEM
++
++#ifdef _MSC_VER
++#include <direct.h>
++#endif
++
++#define TMP_DIR_PREFIX "tmpDir-"
++/* len is length of tmpDir name, assuming
++ * len does not include null terminating character */
++char* create_tmp_dir(char *tmpDir, int len)
++{
++    if (len < (int)XSTR_SIZEOF(TMP_DIR_PREFIX))
++        return NULL;
++
++    XMEMCPY(tmpDir, TMP_DIR_PREFIX, XSTR_SIZEOF(TMP_DIR_PREFIX));
++
++    if (mymktemp(tmpDir, len, len - XSTR_SIZEOF(TMP_DIR_PREFIX)) == NULL)
++        return NULL;
++
++#ifdef _MSC_VER
++    if (_mkdir(tmpDir) != 0)
++        return NULL;
++#elif defined(__CYGWIN__) || defined(__MINGW32__)
++    if (mkdir(tmpDir) != 0)
++        return NULL;
++#else
++    if (mkdir(tmpDir, 0700) != 0)
++        return NULL;
++#endif
++
++    return tmpDir;
++}
++
++int rem_dir(const char* dirName)
++{
++#ifdef _MSC_VER
++    if (_rmdir(dirName) != 0)
++        return -1;
++#else
++    if (rmdir(dirName) != 0)
++        return -1;
++#endif
++    return 0;
++}
++
++int rem_file(const char* fileName)
++{
++#ifdef _MSC_VER
++    if (_unlink(fileName) != 0)
++        return -1;
++#else
++    if (unlink(fileName) != 0)
++        return -1;
++#endif
++    return 0;
++}
++
++int copy_file(const char* in, const char* out)
++{
++    byte buf[100];
++    XFILE inFile = XBADFILE;
++    XFILE outFile = XBADFILE;
++    size_t sz;
++    int ret = -1;
++
++    inFile = XFOPEN(in, "rb");
++    if (inFile == XBADFILE)
++        goto cleanup;
++
++    outFile = XFOPEN(out, "wb");
++    if (outFile == XBADFILE)
++        goto cleanup;
++
++    while ((sz = XFREAD(buf, 1, sizeof(buf), inFile)) != 0) {
++        if (XFWRITE(buf, 1, sz, outFile) != sz)
++            goto cleanup;
++    }
++
++    ret = 0;
++cleanup:
++    if (inFile != XBADFILE)
++        XFCLOSE(inFile);
++    if (outFile != XBADFILE)
++        XFCLOSE(outFile);
++    return ret;
++}
++#endif /* !NO_FILESYSTEM */
++
++#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \
++    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
++
++/* This set of memio functions allows for more fine tuned control of the TLS
++ * connection operations. For new tests, try to use ssl_memio first. */
++
++#define HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES
++
++#define TEST_MEMIO_BUF_SZ (64 * 1024)
++struct test_memio_ctx
++{
++    byte c_buff[TEST_MEMIO_BUF_SZ];
++    int c_len;
++    const char* c_ciphers;
++    byte s_buff[TEST_MEMIO_BUF_SZ];
++    int s_len;
++    const char* s_ciphers;
++};
++
++int test_memio_do_handshake(WOLFSSL *ssl_c, WOLFSSL *ssl_s,
++    int max_rounds, int *rounds);
++int test_memio_setup(struct test_memio_ctx *ctx,
++    WOLFSSL_CTX **ctx_c, WOLFSSL_CTX **ctx_s, WOLFSSL **ssl_c, WOLFSSL **ssl_s,
++    method_provider method_c, method_provider method_s);
++
++static WC_INLINE int test_memio_write_cb(WOLFSSL *ssl, char *data, int sz,
++    void *ctx)
++{
++    struct test_memio_ctx *test_ctx;
++    byte *buf;
++    int *len;
++
++    test_ctx = (struct test_memio_ctx*)ctx;
++
++    if (wolfSSL_GetSide(ssl) == WOLFSSL_SERVER_END) {
++        buf = test_ctx->c_buff;
++        len = &test_ctx->c_len;
++    }
++    else {
++        buf = test_ctx->s_buff;
++        len = &test_ctx->s_len;
++    }
++
++    if ((unsigned)(*len + sz) > TEST_MEMIO_BUF_SZ)
++            return WOLFSSL_CBIO_ERR_WANT_READ;
++
++    XMEMCPY(buf + *len, data, sz);
++    *len += sz;
++
++    return sz;
++}
++
++static WC_INLINE int test_memio_read_cb(WOLFSSL *ssl, char *data, int sz,
++    void *ctx)
++{
++    struct test_memio_ctx *test_ctx;
++    int read_sz;
++    byte *buf;
++    int *len;
++
++    test_ctx = (struct test_memio_ctx*)ctx;
++
++    if (wolfSSL_GetSide(ssl) == WOLFSSL_SERVER_END) {
++        buf = test_ctx->s_buff;
++        len = &test_ctx->s_len;
++    }
++    else {
++        buf = test_ctx->c_buff;
++        len = &test_ctx->c_len;
++    }
++
++    if (*len == 0)
++        return WOLFSSL_CBIO_ERR_WANT_READ;
++
++    read_sz = sz < *len ? sz : *len;
++
++    XMEMCPY(data, buf, read_sz);
++    XMEMMOVE(buf, buf + read_sz, *len - read_sz);
++
++    *len -= read_sz;
++
++    return read_sz;
++}
++
++int test_memio_do_handshake(WOLFSSL *ssl_c, WOLFSSL *ssl_s,
++    int max_rounds, int *rounds)
++{
++    byte handshake_complete = 0, hs_c = 0, hs_s = 0;
++    int ret, err;
++
++    if (rounds != NULL)
++        *rounds = 0;
++    while (!handshake_complete && max_rounds > 0) {
++        if (!hs_c) {
++            ret = wolfSSL_connect(ssl_c);
++            if (ret == WOLFSSL_SUCCESS) {
++                hs_c = 1;
++            }
++            else {
++                err = wolfSSL_get_error(ssl_c, ret);
++                if (err != WOLFSSL_ERROR_WANT_READ &&
++                    err != WOLFSSL_ERROR_WANT_WRITE)
++                    return -1;
++            }
++        }
++        if (!hs_s) {
++            ret = wolfSSL_accept(ssl_s);
++            if (ret == WOLFSSL_SUCCESS) {
++                hs_s = 1;
++            }
++            else {
++                err = wolfSSL_get_error(ssl_s, ret);
++                if (err != WOLFSSL_ERROR_WANT_READ &&
++                    err != WOLFSSL_ERROR_WANT_WRITE)
++                    return -1;
++            }
++        }
++        handshake_complete = hs_c && hs_s;
++        max_rounds--;
++        if (rounds != NULL)
++            *rounds = *rounds + 1;
++    }
++
++    if (!handshake_complete)
++        return -1;
++
++    return 0;
++}
++
++int test_memio_setup(struct test_memio_ctx *ctx,
++    WOLFSSL_CTX **ctx_c, WOLFSSL_CTX **ctx_s, WOLFSSL **ssl_c, WOLFSSL **ssl_s,
++    method_provider method_c, method_provider method_s)
++{
++    int ret;
++
++    if (ctx_c != NULL && *ctx_c == NULL) {
++        *ctx_c = wolfSSL_CTX_new(method_c());
++        if (*ctx_c == NULL)
++            return -1;
++#ifndef NO_CERTS
++        ret = wolfSSL_CTX_load_verify_locations(*ctx_c, caCertFile, 0);
++        if (ret != WOLFSSL_SUCCESS)
++            return -1;
++#endif /* NO_CERTS */
++        wolfSSL_SetIORecv(*ctx_c, test_memio_read_cb);
++        wolfSSL_SetIOSend(*ctx_c, test_memio_write_cb);
++        if (ctx->c_ciphers != NULL) {
++            ret = wolfSSL_CTX_set_cipher_list(*ctx_c, ctx->c_ciphers);
++            if (ret != WOLFSSL_SUCCESS)
++                return -1;
++        }
++    }
++
++    if (ctx_s != NULL && *ctx_s == NULL) {
++        *ctx_s = wolfSSL_CTX_new(method_s());
++        if (*ctx_s == NULL)
++            return -1;
++#ifndef NO_CERTS
++        ret = wolfSSL_CTX_use_PrivateKey_file(*ctx_s, svrKeyFile,
++            WOLFSSL_FILETYPE_PEM);
++        if (ret != WOLFSSL_SUCCESS)
++            return- -1;
++        ret = wolfSSL_CTX_use_certificate_file(*ctx_s, svrCertFile,
++                                               WOLFSSL_FILETYPE_PEM);
++        if (ret != WOLFSSL_SUCCESS)
++            return -1;
++#endif
++        wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
++        wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
++        if (ctx->s_ciphers != NULL) {
++            ret = wolfSSL_CTX_set_cipher_list(*ctx_s, ctx->s_ciphers);
++            if (ret != WOLFSSL_SUCCESS)
++                return -1;
++        }
++    }
++
++    if (ctx_c != NULL && ssl_c != NULL) {
++        *ssl_c = wolfSSL_new(*ctx_c);
++        if (*ssl_c == NULL)
++            return -1;
++        wolfSSL_SetIOWriteCtx(*ssl_c, ctx);
++        wolfSSL_SetIOReadCtx(*ssl_c, ctx);
++    }
++    if (ctx_s != NULL && ssl_s != NULL) {
++        *ssl_s = wolfSSL_new(*ctx_s);
++        if (*ssl_s == NULL)
++            return -1;
++        wolfSSL_SetIOWriteCtx(*ssl_s, ctx);
++        wolfSSL_SetIOReadCtx(*ssl_s, ctx);
++#if !defined(NO_DH)
++        SetDH(*ssl_s);
++#endif
++    }
++
++    return 0;
++}
++#endif
++
++#if !defined(SINGLE_THREADED) && defined(WOLFSSL_COND)
++void signal_ready(tcp_ready* ready)
++{
++    THREAD_CHECK_RET(wolfSSL_CondStart(&ready->cond));
++    ready->ready = 1;
++    THREAD_CHECK_RET(wolfSSL_CondSignal(&ready->cond));
++    THREAD_CHECK_RET(wolfSSL_CondEnd(&ready->cond));
++}
++#endif
++
++void wait_tcp_ready(func_args* args)
++{
++#if !defined(SINGLE_THREADED) && defined(WOLFSSL_COND)
++    tcp_ready* ready = args->signal;
++    THREAD_CHECK_RET(wolfSSL_CondStart(&ready->cond));
++    if (!ready->ready) {
++        THREAD_CHECK_RET(wolfSSL_CondWait(&ready->cond));
++    }
++    ready->ready = 0; /* reset */
++    THREAD_CHECK_RET(wolfSSL_CondEnd(&ready->cond));
++#else
++    /* no threading wait or single threaded */
++    (void)args;
++#endif
++}
++
++#ifndef SINGLE_THREADED
++/* Start a thread.
++ *
++ * @param [in]  fun     Function to execute in thread.
++ * @param [in]  args    Object to send to function in thread.
++ * @param [out] thread  Handle to thread.
++ */
++void start_thread(THREAD_CB fun, func_args* args, THREAD_TYPE* thread)
++{
++    THREAD_CHECK_RET(wolfSSL_NewThread(thread, fun, args));
++}
++
++
++/* Join thread to wait for completion.
++ *
++ * @param [in] thread  Handle to thread.
++ */
++void join_thread(THREAD_TYPE thread)
++{
++    THREAD_CHECK_RET(wolfSSL_JoinThread(thread));
++}
++#endif /* SINGLE_THREADED */
+diff --git a/testsuite/testsuite.c b/testsuite/testsuite.c
+index 1b6df1b16..4d6fa475d 100644
+--- a/testsuite/testsuite.c
++++ b/testsuite/testsuite.c
+@@ -44,6 +44,10 @@
+ #include <examples/server/server.h>
+ #include <examples/client/client.h>
+ 
++<<<<<<< HEAD
++=======
++#include "tests/utils.h"
++>>>>>>> b32ff0b0b (Rename utils.c to utils.h)
+ 
+ #ifndef NO_SHA256
+ void file_test(const char* file, byte* check);
+-- 
+2.41.0
+

--- a/wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
+++ b/wolfssl/2001-Merge-pull-request-6700-from-julek-wolfssl-dtls13-do.patch
@@ -1,0 +1,333 @@
+From 73ef9ff73692c43c86f9f7975d7c1639e39a7976 Mon Sep 17 00:00:00 2001
+From: JacobBarthelmeh <jacob@wolfssl.com>
+Date: Fri, 25 Aug 2023 09:34:53 -0600
+Subject: [PATCH 2/2] Merge pull request #6700 from
+ julek-wolfssl/dtls13-downgrade-acks
+
+DTLS 1.3: do not send ACKs until we negotiate 1.3 (through SH)
+
+(cherry picked from commit 14deb7afdabf6394460f3e5141db192f6a14e620)
+---
+ async-check.sh     |  2 +-
+ src/dtls.c         |  1 +
+ src/dtls13.c       | 48 +++++++++++++++++++++++++++++++++++++---------
+ src/internal.c     | 13 ++++++++++++-
+ src/ssl.c          | 12 ++++++------
+ src/tls13.c        |  7 +++++++
+ tests/api.c        |  2 +-
+ tests/utils.h      | 13 ++++++++++++-
+ wolfssl/internal.h |  6 ++++++
+ 9 files changed, 85 insertions(+), 19 deletions(-)
+
+diff --git a/async-check.sh b/async-check.sh
+index 206fd4ff6..5a0246940 100755
+--- a/async-check.sh
++++ b/async-check.sh
+@@ -91,7 +91,7 @@ set -e
+ 
+ if [ -d ./async ];
+ then
+-    echo "\n\nUsing existing async repo\n\n"
++    echo "Using existing async repo"
+ else
+     # make a clone of the wolfAsyncCrypt repository
+     git clone --depth 1 $ASYNC_REPO async
+diff --git a/src/dtls.c b/src/dtls.c
+index d604b5a2f..9c10169f1 100644
+--- a/src/dtls.c
++++ b/src/dtls.c
+@@ -75,6 +75,7 @@ void DtlsResetState(WOLFSSL* ssl)
+     ssl->options.connectState = CONNECT_BEGIN;
+     ssl->options.acceptState = ACCEPT_BEGIN;
+     ssl->options.handShakeState = NULL_STATE;
++    ssl->options.seenUnifiedHdr = 0;
+     ssl->msgsReceived.got_client_hello = 0;
+     ssl->keys.dtls_handshake_number = 0;
+     ssl->keys.dtls_expected_peer_handshake_number = 0;
+diff --git a/src/dtls13.c b/src/dtls13.c
+index e8a2947d8..6b5dbb9ff 100644
+--- a/src/dtls13.c
++++ b/src/dtls13.c
+@@ -349,6 +349,7 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
+     WOLFSSL_ENTER("Dtls13ProcessBufferedMessages");
+ 
+     while (msg != NULL) {
++        int downgraded = 0;
+         idx = 0;
+ 
+         /* message not in order */
+@@ -359,8 +360,18 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
+         if (!msg->ready)
+             break;
+ 
+-        ret = DoTls13HandShakeMsgType(ssl, msg->fullMsg, &idx, msg->type,
+-                msg->sz, msg->sz);
++        /* We may have DTLS <=1.2 msgs stored from before we knew which version
++         * we were going to use. Interpret correctly. */
++        if (IsAtLeastTLSv1_3(ssl->version)) {
++            ret = DoTls13HandShakeMsgType(ssl, msg->fullMsg, &idx, msg->type,
++                    msg->sz, msg->sz);
++            if (!IsAtLeastTLSv1_3(ssl->version))
++                downgraded = 1;
++        }
++        else {
++            ret = DoHandShakeMsgType(ssl, msg->fullMsg, &idx, msg->type,
++                    msg->sz, msg->sz);
++        }
+ 
+         /* processing certificate_request triggers a connect. The error came
+          * from there, the message can be considered processed successfully.
+@@ -368,7 +379,13 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
+          * waiting to flush the output buffer. */
+         if ((ret == 0 || ret == WANT_WRITE) || (msg->type == certificate_request &&
+                          ssl->options.handShakeDone && ret == WC_PENDING_E)) {
+-            Dtls13MsgWasProcessed(ssl, (enum HandShakeType)msg->type);
++            if (IsAtLeastTLSv1_3(ssl->version))
++                Dtls13MsgWasProcessed(ssl, (enum HandShakeType)msg->type);
++            else if (downgraded)
++                /* DoHandShakeMsgType normally handles the hs number but if
++                 * DoTls13HandShakeMsgType processed 1.2 msgs then this wasn't
++                 * incremented. */
++                ssl->keys.dtls_expected_peer_handshake_number++;
+ 
+             ssl->dtls_rx_msg_list = msg->next;
+             DtlsMsgDelete(msg, ssl->heap);
+@@ -622,7 +639,7 @@ static void Dtls13RtxRecordUnlink(WOLFSSL* ssl, Dtls13RtxRecord** prevNext,
+     *prevNext = r->next;
+ }
+ 
+-static void Dtls13RtxFlushBuffered(WOLFSSL* ssl, byte keepNewSessionTicket)
++void Dtls13RtxFlushBuffered(WOLFSSL* ssl, byte keepNewSessionTicket)
+ {
+     Dtls13RtxRecord *r, **prevNext;
+ 
+@@ -803,10 +820,16 @@ static int Dtls13RtxMsgRecvd(WOLFSSL* ssl, enum HandShakeType hs,
+             Dtls13MaybeSaveClientHello(ssl);
+ 
+         /* In the handshake, receiving part of the next flight, acknowledge the
+-           sent flight. The only exception is, on the server side, receiving the
+-           last client flight does not ACK any sent new_session_ticket
+-           messages. */
+-        Dtls13RtxFlushBuffered(ssl, 1);
++         * sent flight. */
++        /* On the server side, receiving the last client flight does not ACK any
++         * sent new_session_ticket messages. */
++        /* We don't want to clear the buffer until we have done version
++         * negotiation in the SH or have received a unified header in the
++         * DTLS record. */
++        if (ssl->options.serverState >= SERVER_HELLO_COMPLETE ||
++                    ssl->options.seenUnifiedHdr)
++            /* Use 1.2 API to clear 1.2 buffers too */
++            DtlsMsgPoolReset(ssl);
+     }
+ 
+     if (ssl->keys.dtls_peer_handshake_number <
+@@ -850,6 +873,8 @@ static int Dtls13RtxMsgRecvd(WOLFSSL* ssl, enum HandShakeType hs,
+ void Dtls13FreeFsmResources(WOLFSSL* ssl)
+ {
+     Dtls13RtxFlushAcks(ssl);
++    /* Use 1.2 API to clear 1.2 buffers too */
++    DtlsMsgPoolReset(ssl);
+     Dtls13RtxFlushBuffered(ssl, 0);
+ }
+ 
+@@ -2468,7 +2493,12 @@ int Dtls13RtxTimeout(WOLFSSL* ssl)
+ {
+     int ret = 0;
+ 
+-    if (ssl->dtls13Rtx.seenRecords != NULL) {
++    /* We don't want to send acks until we have done version
++     * negotiation in the SH or have received a unified header in the
++     * DTLS record. */
++    if (ssl->dtls13Rtx.seenRecords != NULL &&
++            (ssl->options.serverState >= SERVER_HELLO_COMPLETE ||
++                    ssl->options.seenUnifiedHdr)) {
+         ssl->dtls13Rtx.sendAcks = 0;
+         /* reset fast timeout as we are sending ACKs */
+         ssl->dtls13FastTimeout = 0;
+diff --git a/src/internal.c b/src/internal.c
+index f61c1d7c8..c81fbbcc2 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -8861,6 +8861,10 @@ void DtlsMsgPoolReset(WOLFSSL* ssl)
+         ssl->dtls_tx_msg = NULL;
+         ssl->dtls_tx_msg_list_sz = 0;
+     }
++#ifdef WOLFSSL_DTLS13
++    /* Clear DTLS 1.3 buffer too */
++    Dtls13RtxFlushBuffered(ssl, 1);
++#endif
+ }
+ 
+ 
+@@ -10397,6 +10401,7 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
+     int ret;
+ 
+     if (Dtls13IsUnifiedHeader(*(ssl->buffers.inputBuffer.buffer + *inOutIdx))) {
++        ssl->options.seenUnifiedHdr = 1; /* We can send ACKs to the peer */
+ 
+         /* version 1.3 already negotiated */
+         if (ssl->options.tls1_3) {
+@@ -15197,6 +15202,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
+                 WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
+                 return DUPLICATE_MSG_E;
+             }
++            if (ssl->msgsReceived.got_hello_retry_request) {
++                WOLFSSL_MSG("Received HelloVerifyRequest after a "
++                            "HelloRetryRequest");
++                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
++                return VERSION_ERROR;
++            }
+             ssl->msgsReceived.got_hello_verify_request = 1;
+ 
+             break;
+@@ -15569,7 +15580,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
+ }
+ 
+ 
+-static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
++int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
+                           byte type, word32 size, word32 totalSz)
+ {
+     int ret = 0;
+diff --git a/src/ssl.c b/src/ssl.c
+index fb8ee5c6a..a7077fabb 100644
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -13519,7 +13519,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
+                     return WOLFSSL_FATAL_ERROR;
+                 }
+                 /* if resumption failed, reset needed state */
+-                else if (neededState == SERVER_FINISHED_COMPLETE)
++                else if (neededState == SERVER_FINISHED_COMPLETE) {
+                     if (!ssl->options.resuming) {
+                     #ifdef WOLFSSL_DTLS
+                         if (IsDtlsNotSctpMode(ssl))
+@@ -13528,17 +13528,19 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
+                     #endif
+                             neededState = SERVER_HELLODONE_COMPLETE;
+                     }
+-#ifdef WOLFSSL_DTLS13
++                }
+ 
++#ifdef WOLFSSL_DTLS13
+                 if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version)
+-                    && ssl->dtls13Rtx.sendAcks == 1) {
+-                    ssl->dtls13Rtx.sendAcks = 0;
++                    && ssl->dtls13Rtx.sendAcks == 1
++                    && ssl->options.seenUnifiedHdr) {
+                     /* we aren't negotiated the version yet, so we aren't sure
+                      * the other end can speak v1.3. On the other side we have
+                      * received a unified records, assuming that the
+                      * ServerHello got lost, we will send an empty ACK. In case
+                      * the server is a DTLS with version less than 1.3, it
+                      * should just ignore the message */
++                    ssl->dtls13Rtx.sendAcks = 0;
+                     if ((ssl->error = SendDtls13Ack(ssl)) < 0) {
+                         if (ssl->error == WANT_WRITE)
+                             ssl->dtls13SendingAckOrRtx = 1;
+@@ -13546,8 +13548,6 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
+                         return WOLFSSL_FATAL_ERROR;
+                     }
+                 }
+-
+-
+ #endif /* WOLFSSL_DTLS13 */
+             }
+ 
+diff --git a/src/tls13.c b/src/tls13.c
+index d7b0f17c9..3c3ddba22 100644
+--- a/src/tls13.c
++++ b/src/tls13.c
+@@ -4884,6 +4884,13 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+         WOLFSSL_MSG("HelloRetryRequest format");
+         *extMsgType = hello_retry_request;
+ 
++        if (ssl->msgsReceived.got_hello_verify_request) {
++            WOLFSSL_MSG("Received HelloRetryRequest after a "
++                        "HelloVerifyRequest");
++            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
++            return VERSION_ERROR;
++        }
++
+         /* A HelloRetryRequest comes in as an ServerHello for MiddleBox compat.
+          * Found message to be a HelloRetryRequest.
+          * Don't allow more than one HelloRetryRequest or ServerHello.
+diff --git a/tests/api.c b/tests/api.c
+index 9d5d1933e..db617c3f0 100644
+--- a/tests/api.c
++++ b/tests/api.c
+@@ -5296,7 +5296,7 @@ static WC_INLINE int test_ssl_memio_write_cb(WOLFSSL *ssl, char *data, int sz,
+     }
+ 
+     if ((unsigned)(*len + sz) > TEST_SSL_MEMIO_BUF_SZ)
+-            return WOLFSSL_CBIO_ERR_WANT_READ;
++        return WOLFSSL_CBIO_ERR_WANT_WRITE;
+ 
+     XMEMCPY(buf + *len, data, sz);
+     *len += sz;
+diff --git a/tests/utils.h b/tests/utils.h
+index e50615d72..9b065ad69 100644
+--- a/tests/utils.h
++++ b/tests/utils.h
+@@ -119,6 +119,17 @@ cleanup:
+ /* This set of memio functions allows for more fine tuned control of the TLS
+  * connection operations. For new tests, try to use ssl_memio first. */
+ 
++/* To dump the memory in gdb use
++ *   dump memory client.bin test_ctx.c_buff test_ctx.c_buff+test_ctx.c_len
++ *   dump memory server.bin test_ctx.s_buff test_ctx.s_buff+test_ctx.s_len
++ * This can be imported into Wireshark by transforming the file with
++ *   od -Ax -tx1 -v client.bin > client.bin.hex
++ *   od -Ax -tx1 -v server.bin > server.bin.hex
++ * And then loading test_output.dump.hex into Wireshark using the
++ * "Import from Hex Dump..." option ion and selecting the TCP
++ * encapsulation option.
++ */
++
+ #define HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES
+ 
+ #define TEST_MEMIO_BUF_SZ (64 * 1024)
+@@ -157,7 +168,7 @@ static WC_INLINE int test_memio_write_cb(WOLFSSL *ssl, char *data, int sz,
+     }
+ 
+     if ((unsigned)(*len + sz) > TEST_MEMIO_BUF_SZ)
+-            return WOLFSSL_CBIO_ERR_WANT_READ;
++        return WOLFSSL_CBIO_ERR_WANT_WRITE;
+ 
+     XMEMCPY(buf + *len, data, sz);
+     *len += sz;
+diff --git a/wolfssl/internal.h b/wolfssl/internal.h
+index dbe64dda1..0d23baecc 100644
+--- a/wolfssl/internal.h
++++ b/wolfssl/internal.h
+@@ -2040,6 +2040,9 @@ WOLFSSL_LOCAL void InitSSL_CTX_Suites(WOLFSSL_CTX* ctx);
+ WOLFSSL_LOCAL int InitSSL_Suites(WOLFSSL* ssl);
+ WOLFSSL_LOCAL int InitSSL_Side(WOLFSSL* ssl, word16 side);
+ 
++
++WOLFSSL_LOCAL int DoHandShakeMsgType(WOLFSSL* ssl, byte* input,
++        word32* inOutIdx, byte type, word32 size, word32 totalSz);
+ /* for sniffer */
+ WOLFSSL_LOCAL int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+                             word32 size, word32 totalSz, int sniff);
+@@ -4412,6 +4415,7 @@ struct Options {
+     word16            tls:1;              /* using TLS ? */
+     word16            tls1_1:1;           /* using TLSv1.1+ ? */
+     word16            tls1_3:1;           /* using TLSv1.3+ ? */
++    word16            seenUnifiedHdr:1;   /* received msg with unified header */
+     word16            dtls:1;             /* using datagrams ? */
+     word16            dtlsStateful:1;     /* allow stateful processing ? */
+     word16            connReset:1;        /* has the peer reset */
+@@ -6294,6 +6298,8 @@ WOLFSSL_LOCAL int Dtls13HashHandshake(WOLFSSL* ssl, const byte* input,
+ WOLFSSL_LOCAL int Dtls13HashClientHello(const WOLFSSL* ssl, byte* hash,
+         int* hashSz, const byte* body, word32 length, CipherSpecs* specs);
+ WOLFSSL_LOCAL void Dtls13FreeFsmResources(WOLFSSL* ssl);
++WOLFSSL_LOCAL void Dtls13RtxFlushBuffered(WOLFSSL* ssl,
++        byte keepNewSessionTicket);
+ WOLFSSL_LOCAL int Dtls13RtxTimeout(WOLFSSL* ssl);
+ WOLFSSL_LOCAL int Dtls13ProcessBufferedMessages(WOLFSSL* ssl);
+ WOLFSSL_LOCAL int Dtls13CheckAEADFailLimit(WOLFSSL* ssl);
+-- 
+2.41.0
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a DTLS patch for fixing the issue where the client would send acks before version negotiation was complete

Patch comes from https://github.com/wolfSSL/wolfssl/pull/6700

## Motivation and Context
This fixes DTLS 1.3 to 1.2 downgrades in certain edge cases

## How Has This Been Tested?
This patch was tested manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`