### PR TITLE
ci: add 'test:all' task explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           cd third_party/wolfssl
           ./wolfcrypt/test/testwolfcrypt
       - name: Run build and test
-        run: ceedling project:linux verbosity[4]
+        run: ceedling project:linux verbosity[4] test:all
   linux-386:
     runs-on: ubuntu-22.04
     steps:
@@ -58,7 +58,7 @@ jobs:
           cd third_party/wolfssl
           ./wolfcrypt/test/testwolfcrypt
       - name: Run build and test
-        run: ceedling project:linux_386 verbosity[4]
+        run: ceedling project:linux_386 verbosity[4] test:all
   linux-arm64:
     runs-on: ubuntu-22.04
     steps:
@@ -106,7 +106,7 @@ jobs:
       - name: Build dependencies
         run: ceedling project:macos verbosity[4] clobber dependencies:make
       - name: Run build and test
-        run: ceedling project:macos verbosity[4]
+        run: ceedling project:macos verbosity[4] test:all
   macos_arm64:
     runs-on: macos-latest
     steps:
@@ -134,7 +134,7 @@ jobs:
       - name: Build dependencies
         run: ceedling project:windows_64 verbosity[4] clobber dependencies:make
       - name: Run build and test
-        run: ceedling project:windows_64 verbosity[4]
+        run: ceedling project:windows_64 verbosity[4] test:all
   windows-32bit:
     runs-on: windows-2022
     steps:
@@ -150,7 +150,7 @@ jobs:
       - name: Build dependencies
         run: ceedling project:windows_32 verbosity[4] clobber dependencies:make
       - name: Run build and test
-        run: ceedling project:windows_32 verbosity[4]
+        run: ceedling project:windows_32 verbosity[4] test:all
   ios:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add "test:all" task explicitly to all environment instead of using implicit default task.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously github actions uses default task “test:all” for building and testing in some environments like linux, linux_32 etc. But after the recent change of adding verbosity to the build step, ceedling does not run the default task, rather expecting the task explicitly.

This causes github ci not to build and test lightway-core:
[Merge pull request #103 from expressvpn/dtls13-patches · expressvpn/lightway-core@96e6304](https://github.com/expressvpn/lightway-core/actions/runs/5995148143/job/16257745272#step:6:2)

Also adding task explicitly makes the intention clear, on what are we running.

## How Has This Been Tested?
- Tested locally with command:
```
ceedling project:linux verbosity[4] test:all
```
 - Verified github actions for all environment build lightway core properly
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`