### PR TITLE
ssl_ctx: add PQC Keyshares

### DIFF
--- a/linux_arm_no_pqc.yml
+++ b/linux_arm_no_pqc.yml
@@ -5,6 +5,14 @@
 :release_build:
   :output: libhelium.a
 
+:defines:
+  :test:
+    - HE_NO_PQC
+  :test_preprocess:
+    - HE_NO_PQC
+  :release:
+    - HE_NO_PQC
+
 :dependencies:
   :libraries:
     - :name: WolfSSL

--- a/public/he.h
+++ b/public/he.h
@@ -982,6 +982,15 @@ he_padding_type_t he_ssl_ctx_get_padding_type(he_ssl_ctx_t *ctx);
  */
 he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx);
 
+#ifndef HE_NO_PQC
+/**
+ * @brief Sets the client to use PQC Keyshares
+ * @return HE_SUCCESS PQC Keyshares are enabled
+ *
+ */
+he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled);
+#endif // HE_NO_PQC
+
 /**
  * @brief Creates a Helium connection struct
  * @return he_conn_t* Returns a pointer to a valid Helium connection

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -105,6 +105,8 @@ struct he_ssl_ctx {
   he_padding_type_t padding_type;
   /// Use aggressive mode
   bool use_aggressive_mode;
+  /// Use PQC Keyshares
+  bool use_pqc;
 
   /// WolfSSL global context
   WOLFSSL_CTX *wolf_ctx;
@@ -183,6 +185,8 @@ struct he_conn {
   he_padding_type_t padding_type;
   /// Use aggressive mode
   bool use_aggressive_mode;
+  /// Use PQC Keyshares
+  bool use_pqc;
   /// TCP or UDP?
   he_connection_type_t connection_type;
 

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -706,3 +706,16 @@ he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx) {
   ctx->use_aggressive_mode = true;
   return HE_SUCCESS;
 }
+
+
+#ifndef HE_NO_PQC
+he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled) {
+   // Return if ctx is null
+  if(!ctx) {
+    return HE_ERR_NULL_POINTER;
+  }
+
+  ctx->use_pqc = enabled;
+  return HE_SUCCESS;
+}
+#endif

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -507,4 +507,13 @@ he_padding_type_t he_ssl_ctx_get_padding_type(he_ssl_ctx_t *ctx);
  */
 he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx);
 
+#ifndef HE_NO_PQC
+/**
+ * @brief Sets the client to use PQC Keyshares
+ * @return HE_SUCCESS PQC Keyshares are enabled
+ *
+ */
+he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled);
+#endif // HE_NO_PQC
+
 #endif  // SSL_CTX_H

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -1375,6 +1375,7 @@ void test_he_internal_conn_configure_no_version(void) {
   ssl_ctx.disable_roaming_connections = true;
   ssl_ctx.padding_type = HE_PADDING_FULL;
   ssl_ctx.use_aggressive_mode = true;
+  ssl_ctx.use_pqc = true;
   ssl_ctx.connection_type = HE_CONNECTION_TYPE_STREAM;
 
   ssl_ctx.maximum_supported_version.major_version = 1;
@@ -1398,6 +1399,7 @@ void test_he_internal_conn_configure_no_version(void) {
   TEST_ASSERT_EQUAL(conn.disable_roaming_connections, ssl_ctx.disable_roaming_connections);
   TEST_ASSERT_EQUAL(conn.padding_type, ssl_ctx.padding_type);
   TEST_ASSERT_EQUAL(conn.use_aggressive_mode, ssl_ctx.use_aggressive_mode);
+  TEST_ASSERT_EQUAL(conn.use_pqc, ssl_ctx.use_pqc);
   TEST_ASSERT_EQUAL(conn.connection_type, ssl_ctx.connection_type);
 
   TEST_ASSERT_EQUAL(conn.protocol_version.major_version,

--- a/test/he/test_conn_connect.c
+++ b/test/he/test_conn_connect.c
@@ -197,3 +197,46 @@ void test_he_client_connect_wolf_tls_connect_success(void) {
   int res2 = he_conn_client_connect(conn, ctx, NULL, NULL);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 }
+
+#ifndef HE_NO_PQC
+void test_he_client_connect_pqc_keyshare_udp(void) {
+  ctx->use_pqc = true;
+
+  // Wolf set up
+  setup_dtls_expectations();
+  wolfSSL_UseKeyShare_ExpectAndReturn(test_wolf_ssl, WOLFSSL_P256_KYBER_LEVEL1, SSL_SUCCESS);
+
+  wolfSSL_negotiate_ExpectAndReturn(test_wolf_ssl, SSL_SUCCESS);
+  // For this test it doesn't matter what it's called with as long as it's called
+  // Revisit this as part of the audit
+  wolfSSL_write_IgnoreAndReturn(100);
+  wolfSSL_dtls_get_current_timeout_ExpectAndReturn(test_wolf_ssl, 1);
+  wolfSSL_version_ExpectAndReturn(test_wolf_ssl, DTLS1_3_VERSION);
+  wolfSSL_dtls13_use_quick_timeout_ExpectAndReturn(test_wolf_ssl, true);
+
+  int res2 = he_conn_client_connect(conn, ctx, NULL, NULL);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
+}
+
+void test_he_client_connect_pqc_keyshare_tcp(void) {
+  ctx->use_pqc = true;
+  ctx->connection_type = HE_CONNECTION_TYPE_STREAM;
+
+  // Wolf set up
+  setup_tls_expectations();
+  wolfSSL_UseKeyShare_ExpectAndReturn(test_wolf_ssl, WOLFSSL_P521_KYBER_LEVEL5, SSL_SUCCESS);
+
+  wolfSSL_negotiate_ExpectAndReturn(test_wolf_ssl, SSL_SUCCESS);
+  // For this test it doesn't matter what it's called with as long as it's called
+  // Revisit this as part of the audit
+  wolfSSL_write_IgnoreAndReturn(100);
+
+  // TODO: no need to call wolfSSL_dtls_get_current_timeout if the connection type is stream
+  wolfSSL_dtls_get_current_timeout_ExpectAndReturn(test_wolf_ssl, 1);
+  wolfSSL_version_ExpectAndReturn(test_wolf_ssl, TLS1_3_VERSION);
+  wolfSSL_dtls13_use_quick_timeout_ExpectAndReturn(test_wolf_ssl, true);
+
+  int res2 = he_conn_client_connect(conn, ctx, NULL, NULL);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
+}
+#endif

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -802,6 +802,16 @@ void test_set_aggressive_mode(void) {
   TEST_ASSERT_TRUE(ctx->use_aggressive_mode);
 }
 
+#ifndef HE_NO_PQC
+void test_use_pqc(void) {
+  TEST_ASSERT_FALSE(ctx->use_pqc);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, he_ssl_ctx_set_use_pqc(ctx, true));
+  TEST_ASSERT_TRUE(ctx->use_pqc);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, he_ssl_ctx_set_use_pqc(ctx, false));
+  TEST_ASSERT_FALSE(ctx->use_pqc);
+}
+#endif // HE_NO_PQC
+
 void test_set_nudge_time_cb(void) {
   he_ssl_ctx_set_nudge_time_cb(ctx, nudge_time_cb);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add ability for client to specify PQC Keyshares

## Motivation and Context
This allows the clients to negotiate with hybrid KEMs

## How Has This Been Tested?
Manually tested with internal tooling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`