### PR TITLE
doc: fix bugs in public header generator

### DIFF
--- a/include/he.h
+++ b/include/he.h
@@ -467,4 +467,4 @@ typedef struct he_wire_hdr {
 static const uint64_t HE_PACKET_SESSION_REJECT = 0xFFFFFFFFFFFFFFFF;
 static const uint64_t HE_PACKET_SESSION_EMPTY = 0x0000000000000000;
 
-#endif // HE_H
+#endif  // HE_H

--- a/public/he.h
+++ b/public/he.h
@@ -983,13 +983,43 @@ he_padding_type_t he_ssl_ctx_get_padding_type(he_ssl_ctx_t *ctx);
 he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx);
 
 #ifndef HE_NO_PQC
+
 /**
  * @brief Sets the client to use PQC Keyshares
  * @return HE_SUCCESS PQC Keyshares are enabled
  *
  */
 he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled);
-#endif // HE_NO_PQC
+
+#endif  // HE_NO_PQC
+
+/**
+ * D/TLS is a UDP based protocol and requires the application
+ * (rather than the OS as with TCP) to keep track of the need to do
+ * retransmits on packet loss.
+ *
+ * Currently Wolf has timeouts based in seconds. However this is not
+ * sufficient for our goal of sub-second connection times.
+ *
+ * As WolfSSL lacks millisecond timers we use its internal timers but
+ * change its definition to be in 100 millisecond intervals instead of
+ * seconds. So a wolf timeout of 1 second means 100 milliseconds.
+ *
+ * By default wolf's DTLS max timeout is 64 seconds which translates to
+ * 6.4 seconds. Since it scales from 1 to 64 by a factor
+ * of 2 each timeout. The total timeout is 12.7 seconds with this scaling
+ * which for our purposes is plenty.
+ */
+#define HE_WOLF_TIMEOUT_MULTIPLIER 100
+
+#define HE_WOLF_RENEGOTIATION_TIMEOUT_MULTIPLIER 100
+
+/**
+ * Divider to use when wolfSSL signals that it wants to perform a short
+ * timeout to check for any additional out of order messages before
+ * performing retransmission.
+ */
+#define HE_WOLF_QUICK_TIMEOUT_DIVIDER 4
 
 /**
  * @brief Creates a Helium connection struct

--- a/python/c-header.tx
+++ b/python/c-header.tx
@@ -15,6 +15,6 @@ TypeDef: 'typedef' ID inner_name=ID? /\{(.|\n)*?\}/ name=ID ';';
 
 DocString: /\/\*\*(.|\n)*?\*\//;
 
-PreProcessorDirective: /#.*/;
+PreProcessorDirective: doc=DocString? /#/ keyword=ID content=/.*/;
 DoubleSlashComment: /\/\/.*/;
 StarComment: /\/\*(.|\n)*?\*\//;

--- a/python/make_header.py
+++ b/python/make_header.py
@@ -24,8 +24,9 @@ from textx import metamodel_from_file
 c_header = metamodel_from_file("c-header.tx")
 
 FunDecl = c_header["FunDecl"]
+PreProcessorDirective = c_header["PreProcessorDirective"]
 
-ENDIF_HE_H = "#endif // HE_H"
+ENDIF_HE_H = "#endif  // HE_H"
 
 
 def print_fundecl(fundecl):
@@ -40,7 +41,7 @@ def print_fundecl(fundecl):
 
     if fundecl.doc:
         print(
-            "%s%s%s%s(%s);\n"
+            "%s\n%s%s%s(%s);\n"
             % (fundecl.doc, fundecl.attr, fundecl.type, fundecl.name, fundecl.parms)
         )
     else:
@@ -48,6 +49,13 @@ def print_fundecl(fundecl):
             "%s%s%s(%s);\n" % (fundecl.attr, fundecl.type, fundecl.name, fundecl.parms)
         )
 
+def print_preproc(preproc):
+    if preproc.doc:
+        print("%s\n#%s %s\n"
+              % (preproc.doc, preproc.keyword, preproc.content)
+              )
+    else:
+        print("#%s %s\n" % (statement.keyword, statement.content))
 
 include_header = sys.argv[1]
 print("Including header", include_header, file=sys.stderr)
@@ -60,7 +68,9 @@ for header in sys.argv[2:]:
     print("Processing header file", header, file=sys.stderr)
     program = c_header.model_from_file(header)
     for statement in program.statements:
+        if isinstance(statement, PreProcessorDirective) and "include" not in statement.keyword and "_H" not in statement.content:
+            print_preproc(statement)
         if isinstance(statement, FunDecl) and "internal" not in statement.name:
             print_fundecl(statement)
 
-print(ENDIF_HE_H, end="")
+print(ENDIF_HE_H, end="\n")

--- a/python/make_public_header.sh
+++ b/python/make_public_header.sh
@@ -19,8 +19,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-python make_header.py ../include/he.h ../src/he/memory.h ../src/he/ssl_ctx.h ../src/he/conn.h ../src/he/flow.h ../src/he/plugin_chain.h ../src/he/client.h ../src/he/utils.h >> he.h
+# Generate
+python make_header.py \
+    ../include/he.h \
+    ../src/he/memory.h \
+    ../src/he/ssl_ctx.h \
+    ../src/he/conn.h \
+    ../src/he/flow.h \
+    ../src/he/plugin_chain.h \
+    ../src/he/client.h \
+    ../src/he/utils.h > he.h
 
-# format he.h
+# Format
 clang-format -style=file -i he.h
-

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -209,7 +209,6 @@ he_return_code_t he_ssl_ctx_start(he_ssl_ctx_t *ctx) {
       res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx, "TLS13-AES256-GCM-SHA384");
     }
   } else {
-
     res = wolfSSL_CTX_SetMinVersion(ctx->wolf_ctx, WOLFSSL_DTLSV1_2);
     // Fail if the minimum version can't be set
     if(res != SSL_SUCCESS) {
@@ -217,9 +216,11 @@ he_return_code_t he_ssl_ctx_start(he_ssl_ctx_t *ctx) {
     }
 
     if(ctx->use_chacha) {
-      res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx, "TLS13-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305");
+      res = wolfSSL_CTX_set_cipher_list(
+          ctx->wolf_ctx, "TLS13-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305");
     } else {
-      res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx, "TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384");
+      res = wolfSSL_CTX_set_cipher_list(ctx->wolf_ctx,
+                                        "TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384");
     }
   }
 
@@ -707,10 +708,9 @@ he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx) {
   return HE_SUCCESS;
 }
 
-
 #ifndef HE_NO_PQC
 he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled) {
-   // Return if ctx is null
+  // Return if ctx is null
   if(!ctx) {
     return HE_ERR_NULL_POINTER;
   }

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -508,12 +508,14 @@ he_padding_type_t he_ssl_ctx_get_padding_type(he_ssl_ctx_t *ctx);
 he_return_code_t he_ssl_ctx_set_aggressive_mode(he_ssl_ctx_t *ctx);
 
 #ifndef HE_NO_PQC
+
 /**
  * @brief Sets the client to use PQC Keyshares
  * @return HE_SUCCESS PQC Keyshares are enabled
  *
  */
 he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled);
-#endif // HE_NO_PQC
+
+#endif  // HE_NO_PQC
 
 #endif  // SSL_CTX_H


### PR DESCRIPTION
## Description
Fixed a pre-existing bug in the public header generator which was revealed by the addition of PQC APIs by #105.

## Motivation and Context
The public header `public/he.h` should be generated correctly. Developer should never need to "patch" the public/he.h manually.

## How Has This Been Tested?
Regenerate the public header using the script and confirmed it produced correct result.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`