### PR TITLE
api: remove deprecated function he_conn_set_auth_buffer

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -1172,22 +1172,6 @@ he_return_code_t he_conn_set_auth_token(he_conn_t *conn, const uint8_t *token, s
 bool he_conn_is_auth_token_set(const he_conn_t *conn);
 
 /**
- * @brief Sets the opaque buffer Helium should use to authenticate with.
- * @param conn A pointer to a valid connection
- * @param auth_type the authentication type to pass to the server
- * @param buffer A pointer to the authentication buffer to use
- * @param length The length of the buffer in bytes.
- *
- * @return HE_SUCCESS the auth buffer has been set
- * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
- *
- * @deprecated This function is deprecated. It just calls he_conn_set_auth_buffer2 which sets the
- * auth_type to HE_AUTH_TYPE_CB internally.
- */
-he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
-                                         uint16_t length);
-
-/**
  * @brief Sets the opaque buffer Helium should use to authenticate with
  * @param conn A pointer to a valid connection
  * @param buffer A pointer to the authentication buffer to use

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -973,11 +973,6 @@ bool he_conn_is_auth_token_set(const he_conn_t *conn) {
   return (conn->auth_type == HE_AUTH_TYPE_TOKEN && conn->auth_buffer_length != 0);
 }
 
-he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
-                                         uint16_t length) {
-  return he_conn_set_auth_buffer2(conn, buffer, length);
-}
-
 he_return_code_t he_conn_set_auth_buffer2(he_conn_t *conn, const uint8_t *buffer, uint16_t length) {
   if(conn == NULL || buffer == NULL) {
     return HE_ERR_NULL_POINTER;

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -182,22 +182,6 @@ he_return_code_t he_conn_set_auth_token(he_conn_t *conn, const uint8_t *token, s
 bool he_conn_is_auth_token_set(const he_conn_t *conn);
 
 /**
- * @brief Sets the opaque buffer Helium should use to authenticate with.
- * @param conn A pointer to a valid connection
- * @param auth_type the authentication type to pass to the server
- * @param buffer A pointer to the authentication buffer to use
- * @param length The length of the buffer in bytes.
- *
- * @return HE_SUCCESS the auth buffer has been set
- * @return HE_ERR_STRING_TOO_LONG if length is greater than the maximum buffer size
- *
- * @deprecated This function is deprecated. It just calls he_conn_set_auth_buffer2 which sets the
- * auth_type to HE_AUTH_TYPE_CB internally.
- */
-he_return_code_t he_conn_set_auth_buffer(he_conn_t *conn, uint8_t auth_type, const uint8_t *buffer,
-                                         uint16_t length);
-
-/**
  * @brief Sets the opaque buffer Helium should use to authenticate with
  * @param conn A pointer to a valid connection
  * @param buffer A pointer to the authentication buffer to use


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove function `he_conn_set_auth_buffer` which has been deprecated since https://github.com/expressvpn/lightway-core/pull/27. 

## Motivation and Context
We recently added a new `HE_AUTH_TYPE_TOKEN` auth type in https://github.com/expressvpn/lightway-core/pull/108. Removing the deprecated function to reduce confusion.

## How Has This Been Tested?
Tested on CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] All active GitHub checks are passing  
- [X] The correct base branch is being used, if not `main`