### PR TITLE
liboqs: add a patch to use arc4random_buf

### DIFF
--- a/ios.yml
+++ b/ios.yml
@@ -16,6 +16,7 @@
         :source: $HE_LIBOQS_SOURCE
         :tag: $HE_LIBOQS_TAG
       :build:
+        - git apply ../../liboqs/0001-Prefer-arc4random-on-Apple-platforms-1544.patch || true
         - cp ../../cmake/apple.cmake ./apple.cmake
         - cp ../../ios/liboqs-helper.sh ./liboqs-helper.sh
         - "./liboqs-helper.sh -iphoneuniversal"

--- a/liboqs/0001-Prefer-arc4random-on-Apple-platforms-1544.patch
+++ b/liboqs/0001-Prefer-arc4random-on-Apple-platforms-1544.patch
@@ -1,0 +1,89 @@
+From 67f68101cce82cb86651002d201a0f369174f54e Mon Sep 17 00:00:00 2001
+From: Raihaan Shouhell <raihaanhimself@gmail.com>
+Date: Sun, 10 Sep 2023 23:24:52 +0800
+Subject: [PATCH] Prefer arc4random on Apple platforms (#1544)
+
+* Prefer arc4random_buf on Apple platforms
+
+We swap from getentropy() to arc4random_buf on Apple
+platforms as Apple's documentation discourages its use.
+
+This also allows us to not have to use SecCopyRandomBytes
+which can fail. arc4random_buf() however never fails.
+
+* Remove linking to unused Security framework
+
+(cherry picked from commit b3b0fbb16c202280aec20bbeac690c06dd175c5a)
+---
+ src/CMakeLists.txt     |  4 ----
+ src/common/rand/rand.c | 25 ++++++-------------------
+ 2 files changed, 6 insertions(+), 23 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index edce90de..39cc8747 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -60,10 +60,6 @@ endif()
+ if(${OQS_USE_OPENSSL})
+     target_link_libraries(oqs PRIVATE ${OPENSSL_CRYPTO_LIBRARY})
+ endif()
+-if(IOS)
+-    find_library(IOS_SECURITY Security)
+-    target_link_libraries(oqs PUBLIC ${IOS_SECURITY})
+-endif()
+ 
+ target_include_directories(oqs
+                            PUBLIC
+diff --git a/src/common/rand/rand.c b/src/common/rand/rand.c
+index cb7404a4..92ea271d 100644
+--- a/src/common/rand/rand.c
++++ b/src/common/rand/rand.c
+@@ -8,14 +8,7 @@
+ #else
+ #include <unistd.h>
+ #include <strings.h>
+-#if defined(__APPLE__)
+-#include <TargetConditionals.h>
+-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+-#include <Security/SecRandom.h>
+-#else
+-#include <sys/random.h>
+-#endif
+-#else
++#if !defined(__APPLE__)
+ #include <unistd.h>
+ #endif
+ #endif
+@@ -65,6 +58,11 @@ OQS_API void OQS_randombytes(uint8_t *random_array, size_t bytes_to_read) {
+ }
+ 
+ #if !defined(_WIN32)
++#if defined(__APPLE__)
++void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
++	arc4random_buf(random_array, bytes_to_read);
++}
++#else
+ #if defined(OQS_HAVE_GETENTROPY)
+ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
+ 	while (bytes_to_read > 256) {
+@@ -79,17 +77,6 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
+ 	}
+ }
+ #else
+-#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+-void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
+-	int status =
+-	    SecRandomCopyBytes(kSecRandomDefault, bytes_to_read, random_array);
+-
+-	if (status == errSecSuccess) {
+-		perror("OQS_randombytes");
+-		exit(EXIT_FAILURE);
+-	}
+-}
+-#else
+ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
+ 	FILE *handle;
+ 	size_t bytes_read;
+-- 
+2.42.0
+

--- a/macos.yml
+++ b/macos.yml
@@ -18,6 +18,7 @@
       :environment:
         - CC=clang
       :build:
+        - git apply ../../liboqs/0001-Prefer-arc4random-on-Apple-platforms-1544.patch
         - "mkdir -p build"
         - "cd build && cmake -DCMAKE_TOOLCHAIN_FILE=../../cmake/apple.cmake -DPLATFORM=MAC -DDEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET -DCMAKE_REQUIRED_FLAGS=\"-Werror=unguarded-availability-new\" $HE_LIBOQS_BUILD_FLAGS .."
         - "cd build && make all"

--- a/macos_arm64.yml
+++ b/macos_arm64.yml
@@ -18,6 +18,7 @@
       :environment:
         - CC=clang
       :build:
+        - git apply ../../liboqs/0001-Prefer-arc4random-on-Apple-platforms-1544.patch
         - "mkdir -p build"
         - "cd build && cmake -DCMAKE_TOOLCHAIN_FILE=../../cmake/apple.cmake -DPLATFORM=MAC_ARM64 -DDEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET -DCMAKE_REQUIRED_FLAGS=\"-Werror=unguarded-availability-new\" $HE_LIBOQS_BUILD_FLAGS .."
         - "cd build && make all"

--- a/tvos.yml
+++ b/tvos.yml
@@ -16,6 +16,7 @@
         :source: $HE_LIBOQS_SOURCE
         :tag: $HE_LIBOQS_TAG
       :build:
+        - git apply ../../liboqs/0001-Prefer-arc4random-on-Apple-platforms-1544.patch || true
         - cp ../../cmake/apple.cmake ./apple.cmake
         - cp ../../ios/liboqs-helper.sh ./liboqs-helper.sh
         - "./liboqs-helper.sh -appletvuniversal"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a patch from liboqs upstream to prevent failures when generating random numbers

## Motivation and Context
We can quite easily reproduce a failure particularly on the iOS platform and this patch removes any possibility of a failure.

## How Has This Been Tested?
Tested with internal tooling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`