### PR TITLE
VAN-118 Ensure the auth_token_cb is copied from ctx to conn

### DIFF
--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -177,6 +177,7 @@ he_return_code_t he_internal_conn_configure(he_conn_t *conn, he_ssl_ctx_t *ctx) 
   conn->event_cb = ctx->event_cb;
   conn->auth_cb = ctx->auth_cb;
   conn->auth_buf_cb = ctx->auth_buf_cb;
+  conn->auth_token_cb = ctx->auth_token_cb;
   conn->populate_network_config_ipv4_cb = ctx->populate_network_config_ipv4_cb;
 
   // Copy the RNG to allow for generation of session IDs

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -1421,6 +1421,7 @@ void test_he_internal_conn_configure_no_version(void) {
 
   ssl_ctx.auth_buf_cb = (he_auth_buf_cb_t)0x1;
   ssl_ctx.auth_cb = (he_auth_cb_t)0x2;
+  ssl_ctx.auth_token_cb = (he_auth_token_cb_t)0x10;
   ssl_ctx.event_cb = (he_event_cb_t)0x3;
   ssl_ctx.nudge_time_cb = (he_nudge_time_cb_t)0x4;
   ssl_ctx.state_change_cb = (he_state_change_cb_t)0x5;
@@ -1447,6 +1448,7 @@ void test_he_internal_conn_configure_no_version(void) {
 
   TEST_ASSERT_EQUAL(conn.auth_buf_cb, ssl_ctx.auth_buf_cb);
   TEST_ASSERT_EQUAL(conn.auth_cb, ssl_ctx.auth_cb);
+  TEST_ASSERT_EQUAL(conn.auth_token_cb, ssl_ctx.auth_token_cb);
   TEST_ASSERT_EQUAL(conn.event_cb, ssl_ctx.event_cb);
   TEST_ASSERT_EQUAL(conn.nudge_time_cb, ssl_ctx.nudge_time_cb);
   TEST_ASSERT_EQUAL(conn.state_change_cb, ssl_ctx.state_change_cb);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure the `auth_token_cb` is copied from `ctx` to `conn` when setting up a connection.

## Motivation and Context
Fixed a bug which prevent server accepting auth token requests.

## How Has This Been Tested?
Added unit tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`