### PR TITLE
conn: use uint16_t as the type of outside_mtu

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -1209,24 +1209,22 @@ bool he_conn_is_auth_buffer_set(const he_conn_t *conn);
 
 /**
  * @brief Set the MTU for the outside transport mechanism. Usually this will be the MTU of the
- * devices Internet connection.
+ * device's internet connection.
  * @param conn A pointer to a valid connection
  * @param mtu The MTU of the outside transport mechanism in bytes
  * @return HE_SUCCESS The MTU value was set
+ * @return HE_ERR_NULL_POINTER if the conn is NULL
  * @note A default value is not set as although Ethernet is almost always 1500, mobile devices have
- * a wide range of options
- *
- * @caution Setting the MTU will update the MSS clamp size to an optimal value
- * for the new MTU.
+ * a wide range of options.
  */
-int he_conn_set_outside_mtu(he_conn_t *conn, int mtu);
+he_return_code_t he_conn_set_outside_mtu(he_conn_t *conn, uint16_t mtu);
 
 /**
  * @brief Get the MTU value for the outside transport mechanism.
  * @param conn A pointer to a valid connection.
- * @ return int The MTU value in bytes.
+ * @return The MTU value in bytes.
  */
-int he_conn_get_outside_mtu(he_conn_t *conn);
+uint16_t he_conn_get_outside_mtu(he_conn_t *conn);
 
 /**
  * @brief Check if the outside MTU has been set.

--- a/src/he/config.c
+++ b/src/he/config.c
@@ -68,17 +68,3 @@ he_return_code_t he_internal_set_config_string(char *field, const char *value) {
 
   return HE_SUCCESS;
 }
-
-he_return_code_t he_internal_set_config_int(int *field, int value) {
-  // Nothing accepts a negative so far - but we'll tidy this up later if needed
-  if(value < 0) {
-    // Reject negatives
-    return HE_ERR_NEGATIVE_NUMBER;
-  }
-
-  // Set the value
-  *field = value;
-
-  // Return okay
-  return HE_SUCCESS;
-}

--- a/src/he/config.h
+++ b/src/he/config.h
@@ -41,6 +41,5 @@ bool he_internal_config_is_empty_string(const char *string);
 bool he_internal_config_is_string_too_long(const char *string);
 
 he_return_code_t he_internal_set_config_string(char *field, const char *value);
-he_return_code_t he_internal_set_config_int(int *field, int value);
 
 #endif  // CONFIG_H

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -216,10 +216,9 @@ static he_return_code_t he_conn_internal_connect(he_conn_t *conn, he_ssl_ctx_t *
     wolfSSL_dtls_set_using_nonblock(conn->wolf_ssl, 1);
 
     // Set the MTU
-    // TODO Can we change conn->mtu to be uint16_t?
     // No need to tell wolf to include space for its own headers
-    res = wolfSSL_dtls_set_mtu(
-        conn->wolf_ssl, (uint16_t)conn->outside_mtu - HE_PACKET_OVERHEAD + HE_WOLF_MAX_HEADER_SIZE);
+    res = wolfSSL_dtls_set_mtu(conn->wolf_ssl,
+                               conn->outside_mtu - HE_PACKET_OVERHEAD + HE_WOLF_MAX_HEADER_SIZE);
     if(res != SSL_SUCCESS) {
       // MTU size is invalid
       return HE_ERR_INVALID_MTU_SIZE;
@@ -1014,19 +1013,23 @@ bool he_conn_is_auth_buffer_set(const he_conn_t *conn) {
   return conn->auth_buffer_length != 0;
 }
 
-int he_conn_set_outside_mtu(he_conn_t *conn, int mtu) {
+he_return_code_t he_conn_set_outside_mtu(he_conn_t *conn, uint16_t mtu) {
   // Return if conn is null
   if(!conn) {
     return HE_ERR_NULL_POINTER;
   }
 
+  if(mtu <= HE_PACKET_OVERHEAD) {
+    return HE_ERR_INVALID_MTU_SIZE;
+  }
+
   // Set the MTU
-  he_internal_set_config_int(&conn->outside_mtu, mtu);
+  conn->outside_mtu = mtu;
 
   return HE_SUCCESS;
 }
 
-int he_conn_get_outside_mtu(he_conn_t *conn) {
+uint16_t he_conn_get_outside_mtu(he_conn_t *conn) {
   // Return if conn is null
   if(!conn) {
     return 0;
@@ -1041,11 +1044,7 @@ bool he_conn_is_outside_mtu_set(he_conn_t *conn) {
     return false;
   }
 
-  if(conn->outside_mtu) {
-    return true;
-  }
-
-  return false;
+  return (conn->outside_mtu > 0);
 }
 
 size_t he_internal_calculate_data_packet_length(he_conn_t *conn, size_t length) {

--- a/src/he/conn.h
+++ b/src/he/conn.h
@@ -204,24 +204,22 @@ bool he_conn_is_auth_buffer_set(const he_conn_t *conn);
 
 /**
  * @brief Set the MTU for the outside transport mechanism. Usually this will be the MTU of the
- * devices Internet connection.
+ * device's internet connection.
  * @param conn A pointer to a valid connection
  * @param mtu The MTU of the outside transport mechanism in bytes
  * @return HE_SUCCESS The MTU value was set
+ * @return HE_ERR_NULL_POINTER if the conn is NULL
  * @note A default value is not set as although Ethernet is almost always 1500, mobile devices have
- * a wide range of options
- *
- * @caution Setting the MTU will update the MSS clamp size to an optimal value
- * for the new MTU.
+ * a wide range of options.
  */
-int he_conn_set_outside_mtu(he_conn_t *conn, int mtu);
+he_return_code_t he_conn_set_outside_mtu(he_conn_t *conn, uint16_t mtu);
 
 /**
  * @brief Get the MTU value for the outside transport mechanism.
  * @param conn A pointer to a valid connection.
- * @ return int The MTU value in bytes.
+ * @return The MTU value in bytes.
  */
-int he_conn_get_outside_mtu(he_conn_t *conn);
+uint16_t he_conn_get_outside_mtu(he_conn_t *conn);
 
 /**
  * @brief Check if the outside MTU has been set.

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -176,7 +176,7 @@ struct he_conn {
   uint16_t auth_buffer_length;
 
   /// MTU Helium should use for the outside connection (i.e. Internet)
-  int outside_mtu;
+  uint16_t outside_mtu;
 
   void *data;
 
@@ -361,7 +361,6 @@ typedef struct he_msg_extension {
   uint8_t payload_type;
   uint16_t payload_length;
   uint8_t data;
-
 } he_msg_extension_t;
 
 // D/TLS headers + AES crypto fields

--- a/test/he/test_config.c
+++ b/test/he/test_config.c
@@ -66,18 +66,6 @@ void test_he_config_set_string_empty(void) {
   TEST_ASSERT_EQUAL(HE_ERR_EMPTY_STRING, res1);
 }
 
-void test_set_integer(void) {
-  int res1 = he_internal_set_config_int(&conn->outside_mtu, 10);
-  TEST_ASSERT_EQUAL(10, conn->outside_mtu);
-  TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
-}
-
-void test_set_integer_with_negative(void) {
-  int res1 = he_internal_set_config_int(&conn->outside_mtu, -10);
-  TEST_ASSERT_EQUAL(0, conn->outside_mtu);
-  TEST_ASSERT_EQUAL(HE_ERR_NEGATIVE_NUMBER, res1);
-}
-
 void test_config_string_too_long(void) {
   bool res = he_internal_config_is_string_length_okay(bad_string_too_long);
   TEST_ASSERT_FALSE(res);

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -89,7 +89,7 @@ void test_valid_to_connect_auth_buffer(void) {
   int res1 = he_conn_set_auth_buffer2(test, fake_ipv4_packet, sizeof(fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 
-  int res2 = he_conn_set_outside_mtu(test, HE_MAX_WIRE_MTU);
+  he_return_code_t res2 = he_conn_set_outside_mtu(test, HE_MAX_WIRE_MTU);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 
   int res3 = he_conn_is_valid_client(&ssl_ctx, test);
@@ -133,7 +133,7 @@ void test_valid_to_connect_incorrect_protocol(void) {
   int res3 = he_conn_set_protocol_version(test, 0xFF, 0xFF);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res3);
 
-  int res4 = he_conn_set_outside_mtu(test, HE_MAX_WIRE_MTU);
+  he_return_code_t res4 = he_conn_set_outside_mtu(test, HE_MAX_WIRE_MTU);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res4);
 
   int res5 = he_conn_is_valid_client(&ssl_ctx, test);
@@ -322,26 +322,26 @@ void test_is_auth_buffer_set(void) {
 // Other getters and setters
 
 void test_set_mtu(void) {
-  int res1 = he_conn_set_outside_mtu(&conn, 10);
-  TEST_ASSERT_EQUAL(10, conn.outside_mtu);
+  he_return_code_t res1 = he_conn_set_outside_mtu(&conn, 572);
+  TEST_ASSERT_EQUAL(572, conn.outside_mtu);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 }
 
 void test_get_mtu(void) {
-  int res1 = he_conn_set_outside_mtu(&conn, 10);
-  TEST_ASSERT_EQUAL(10, conn.outside_mtu);
+  he_return_code_t res1 = he_conn_set_outside_mtu(&conn, 1460);
+  TEST_ASSERT_EQUAL(1460, conn.outside_mtu);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 
-  int res2 = he_conn_get_outside_mtu(&conn);
-  TEST_ASSERT_EQUAL(10, res2);
+  uint16_t res2 = he_conn_get_outside_mtu(&conn);
+  TEST_ASSERT_EQUAL(1460, res2);
 }
 
 void test_is_mtu_set(void) {
   bool res1 = he_conn_is_outside_mtu_set(&conn);
-  int res2 = he_conn_set_outside_mtu(&conn, 10);
+  he_return_code_t res2 = he_conn_set_outside_mtu(&conn, 1460);
   bool res3 = he_conn_is_outside_mtu_set(&conn);
   TEST_ASSERT_EQUAL(false, res1);
-  TEST_ASSERT_EQUAL(10, conn.outside_mtu);
+  TEST_ASSERT_EQUAL(1460, conn.outside_mtu);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
   TEST_ASSERT_EQUAL(true, res3);
 }
@@ -1386,8 +1386,13 @@ void test_he_conn_set_outside_mtu_conn_null(void) {
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
 }
 
+void test_he_conn_set_outside_mtu_too_small(void) {
+  he_return_code_t res = he_conn_set_outside_mtu(&conn, 100);
+  TEST_ASSERT_EQUAL(HE_ERR_INVALID_MTU_SIZE, res);
+}
+
 void test_he_conn_get_outside_mtu_conn_null(void) {
-  int res = he_conn_get_outside_mtu(NULL);
+  uint16_t res = he_conn_get_outside_mtu(NULL);
   TEST_ASSERT_EQUAL(0, res);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use `uint16_t` as the type of `outside_mtu` and prevent setting outside_mtu to a smaller value than `HE_PACKET_OVERHEAD` (114 bytes).

Fix some tech debts and make setting outside mtu much safer.

## How Has This Been Tested?
Unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`