### PR TITLE
LIT-134 Support payload and identifier in ping/pong message

### DIFF
--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -495,8 +495,19 @@ he_return_code_t he_conn_send_keepalive(he_conn_t *conn) {
   he_msg_ping_t ping = {0};
   ping.msg_header.msgid = HE_MSGID_PING;
 
+  // Set identifier
+  uint16_t id = conn->ping_next_id++;
+  ping.id = htons(id);
+
+  // No payload for keepalive
+  ping.length = 0;
+
   // Send it
-  return he_internal_send_message(conn, (uint8_t *)&ping, sizeof(he_msg_ping_t));
+  he_return_code_t res = he_internal_send_message(conn, (uint8_t *)&ping, sizeof(he_msg_ping_t));
+  if(res == HE_SUCCESS) {
+    conn->ping_pending_id = id;
+  }
+  return res;
 }
 
 // Returns true if current state is valid for sending/receiving the HE_MSGID_SERVER_CONFIG message

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -218,6 +218,11 @@ struct he_conn {
 
   /// Random number generator
   RNG wolf_rng;
+
+  /// Identifier of the next ping message
+  uint16_t ping_next_id;
+  /// Identifier of the ping message pending reply
+  uint16_t ping_pending_id;
 };
 
 struct he_plugin_chain {
@@ -263,12 +268,20 @@ typedef struct he_msg_hdr {
 
 typedef struct he_msg_ping {
   he_msg_hdr_t msg_header;
-  uint32_t payload;
+  /// Identifier for matching the reply message
+  uint16_t id;
+  /// Length of the payload
+  uint16_t length;
+  /// Payload
+  uint8_t payload[];
 } he_msg_ping_t;
 
 typedef struct he_msg_pong {
   he_msg_hdr_t msg_header;
-  uint32_t payload;
+  /// Identifier of the matching ping message
+  uint16_t id;
+  /// Reserved for backward-compatibility
+  uint16_t reserved;
 } he_msg_pong_t;
 
 typedef struct he_msg_auth_hdr {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support identifier and payload in Lightway Ping/Pong messages. The connection will ignore the pong message with a mismatched id.

Also fixed some tech debts:
- Message handler should ignore invalid ping/pong messages
- Message handler should check the return value of he_internal_send_message

This change is backward compatible, but we'll need to rollout the change to server-side first.

## Motivation and Context
Preparation work for adding the Path MTU Discovery feature.

## How Has This Been Tested?
Unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`