### PR TITLE
LIT-134 Adding outside_write_ex_cb and set DF flag when sending ping/pong messages

### DIFF
--- a/include/he.h
+++ b/include/he.h
@@ -344,10 +344,10 @@ typedef he_return_code_t (*he_outside_write_cb_t)(he_conn_t *conn, uint8_t *pack
                                                   void *context);
 
 /// Instruct the outside_write_cb function to set the DF flag on the IP packet
-#define HE_OUTSIDE_WRITE_DONT_FRAGMENT 0x0001
+#define HE_OUTSIDE_WRITE_DONT_FRAGMENT 0x00000001
 
 /// Default flags for outside_write_cb
-#define HE_OUTSIDE_WRITE_DEFAULT_FLAGS 0x0000
+#define HE_OUTSIDE_WRITE_DEFAULT_FLAGS 0x00000000
 
 /**
  * @brief The prototype for the outside write callback function

--- a/include/he.h
+++ b/include/he.h
@@ -335,12 +335,34 @@ typedef he_return_code_t (*he_inside_write_cb_t)(he_conn_t *conn, uint8_t *packe
  * @param length The length of the entire packet in bytes
  * @param context A pointer to the user defined context
  * @see he_conn_set_context Sets the value of the context pointer
+ * @deprecated Use he_outside_write_ex_cb_t instead.
  *
  * Whenever Helium needs to do an outside write this function will be called. On Linux this would
  * usually be writing to a UDP socket to send encrypted data over the Internet.
  */
 typedef he_return_code_t (*he_outside_write_cb_t)(he_conn_t *conn, uint8_t *packet, size_t length,
                                                   void *context);
+
+/// Instruct the outside_write_cb function to set the DF flag on the IP packet
+#define HE_OUTSIDE_WRITE_DONT_FRAGMENT 0x0001
+
+/// Default flags for outside_write_cb
+#define HE_OUTSIDE_WRITE_DEFAULT_FLAGS 0x0000
+
+/**
+ * @brief The prototype for the outside write callback function
+ * @param conn A pointer to the connection that triggered this callback
+ * @param packet A pointer to the packet data
+ * @param length The length of the entire packet in bytes
+ * @param flags A 32-bits field to control the behaviors when doing the outside write function
+ * @param context A pointer to the user defined context
+ * @see he_conn_set_context Sets the value of the context pointer
+ *
+ * Whenever Helium needs to do an outside write this function will be called. On Linux this would
+ * usually be writing to a UDP socket to send encrypted data over the Internet.
+ */
+typedef he_return_code_t (*he_outside_write_ex_cb_t)(he_conn_t *conn, uint8_t *packet,
+                                                     size_t length, uint32_t flags, void *context);
 
 /**
  * @brief The prototype for the network config callback function

--- a/public/he.h
+++ b/public/he.h
@@ -344,10 +344,10 @@ typedef he_return_code_t (*he_outside_write_cb_t)(he_conn_t *conn, uint8_t *pack
                                                   void *context);
 
 /// Instruct the outside_write_cb function to set the DF flag on the IP packet
-#define HE_OUTSIDE_WRITE_DONT_FRAGMENT 0x0001
+#define HE_OUTSIDE_WRITE_DONT_FRAGMENT 0x00000001
 
 /// Default flags for outside_write_cb
-#define HE_OUTSIDE_WRITE_DEFAULT_FLAGS 0x0000
+#define HE_OUTSIDE_WRITE_DEFAULT_FLAGS 0x00000000
 
 /**
  * @brief The prototype for the outside write callback function
@@ -862,7 +862,8 @@ bool he_ssl_ctx_is_inside_write_cb_set(he_ssl_ctx_t *ctx);
 /**
  * @brief Sets the function that will be called when Helium needs to do an outside write.
  * @param ctx A pointer to a valid SSL context
- * @param outside_write_cb  The function to be called when Helium needs to do an outside write
+ * @param outside_write_cb The function to be called when Helium needs to do an outside write
+ * @deprecated Use `he_ssl_ctx_set_outside_write_ex_cb` instead.
  *
  * Helium is platform agnostic and as such does not handle its own I/O. This allows the developer
  * to hook up Helium using the most appropriate methods for their platform.
@@ -872,6 +873,17 @@ bool he_ssl_ctx_is_inside_write_cb_set(he_ssl_ctx_t *ctx);
  */
 void he_ssl_ctx_set_outside_write_cb(he_ssl_ctx_t *ctx, he_outside_write_cb_t outside_write_cb);
 
+/**
+ * @brief Sets the function that will be called when Helium needs to do an outside write.
+ * @param ctx A pointer to a valid SSL context
+ * @param outside_write_cb The function to be called when Helium needs to do an outside write
+ *
+ * Helium is platform agnostic and as such does not handle its own I/O. This allows the developer
+ * to hook up Helium using the most appropriate methods for their platform.
+ *
+ * Outside writes are triggered when encrypted packets need to be sent to the Helium server. On
+ * Linux this would usually be a UDP socket.
+ */
 void he_ssl_ctx_set_outside_write_ex_cb(he_ssl_ctx_t *ctx,
                                         he_outside_write_ex_cb_t outside_write_ex_cb);
 

--- a/public/he.h
+++ b/public/he.h
@@ -335,12 +335,34 @@ typedef he_return_code_t (*he_inside_write_cb_t)(he_conn_t *conn, uint8_t *packe
  * @param length The length of the entire packet in bytes
  * @param context A pointer to the user defined context
  * @see he_conn_set_context Sets the value of the context pointer
+ * @deprecated Use he_outside_write_ex_cb_t instead.
  *
  * Whenever Helium needs to do an outside write this function will be called. On Linux this would
  * usually be writing to a UDP socket to send encrypted data over the Internet.
  */
 typedef he_return_code_t (*he_outside_write_cb_t)(he_conn_t *conn, uint8_t *packet, size_t length,
                                                   void *context);
+
+/// Instruct the outside_write_cb function to set the DF flag on the IP packet
+#define HE_OUTSIDE_WRITE_DONT_FRAGMENT 0x0001
+
+/// Default flags for outside_write_cb
+#define HE_OUTSIDE_WRITE_DEFAULT_FLAGS 0x0000
+
+/**
+ * @brief The prototype for the outside write callback function
+ * @param conn A pointer to the connection that triggered this callback
+ * @param packet A pointer to the packet data
+ * @param length The length of the entire packet in bytes
+ * @param flags A 32-bits field to control the behaviors when doing the outside write function
+ * @param context A pointer to the user defined context
+ * @see he_conn_set_context Sets the value of the context pointer
+ *
+ * Whenever Helium needs to do an outside write this function will be called. On Linux this would
+ * usually be writing to a UDP socket to send encrypted data over the Internet.
+ */
+typedef he_return_code_t (*he_outside_write_ex_cb_t)(he_conn_t *conn, uint8_t *packet,
+                                                     size_t length, uint32_t flags, void *context);
 
 /**
  * @brief The prototype for the network config callback function
@@ -849,6 +871,9 @@ bool he_ssl_ctx_is_inside_write_cb_set(he_ssl_ctx_t *ctx);
  * Linux this would usually be a UDP socket.
  */
 void he_ssl_ctx_set_outside_write_cb(he_ssl_ctx_t *ctx, he_outside_write_cb_t outside_write_cb);
+
+void he_ssl_ctx_set_outside_write_ex_cb(he_ssl_ctx_t *ctx,
+                                        he_outside_write_ex_cb_t outside_write_ex_cb);
 
 /**
  * @brief Called when the host application needs to deliver outside data to be processed by Helium

--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -446,11 +446,10 @@ he_return_code_t he_internal_flow_outside_data_handle_messages(he_conn_t *conn) 
     int resp_pending = 0;
 
     // wolfSSL_version currently doesn't recognize DTLS 1.3. Needs fixing.
-    if (wolfSSL_version(conn->wolf_ssl) == DTLS1_2_VERSION) {
+    if(wolfSSL_version(conn->wolf_ssl) == DTLS1_2_VERSION) {
       resp_pending = wolfSSL_SSL_renegotiate_pending(conn->wolf_ssl);
-    }
-    else {
-      if (wolfSSL_key_update_response(conn->wolf_ssl, &resp_pending) != 0) {
+    } else {
+      if(wolfSSL_key_update_response(conn->wolf_ssl, &resp_pending) != 0) {
         return HE_ERR_SSL_ERROR;
       }
     }

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -86,6 +86,7 @@ struct he_ssl_ctx {
   he_inside_write_cb_t inside_write_cb;
   /// Callback for writing to the outside (i.e. a socket)
   he_outside_write_cb_t outside_write_cb;
+  he_outside_write_ex_cb_t outside_write_ex_cb;
   /// Network config callback
   he_network_config_ipv4_cb_t network_config_ipv4_cb;
   /// Server config callback
@@ -200,6 +201,7 @@ struct he_conn {
   he_inside_write_cb_t inside_write_cb;
   /// Callback for writing to the outside (i.e. a socket)
   he_outside_write_cb_t outside_write_cb;
+  he_outside_write_ex_cb_t outside_write_ex_cb;
   /// Network config callback
   he_network_config_ipv4_cb_t network_config_ipv4_cb;
   /// Server config callback
@@ -223,6 +225,8 @@ struct he_conn {
   uint16_t ping_next_id;
   /// Identifier of the ping message pending reply
   uint16_t ping_pending_id;
+  /// Flags for the next outside write
+  uint32_t outside_write_flags;
 };
 
 struct he_plugin_chain {

--- a/src/he/msg_handlers.c
+++ b/src/he/msg_handlers.c
@@ -56,8 +56,17 @@ he_return_code_t he_handle_msg_ping(he_conn_t *conn, uint8_t *packet, int length
   pong.msg_header.msgid = HE_MSGID_PONG;
   pong.id = ping->id;
 
-  // Send pong
-  return he_internal_send_message(conn, (uint8_t *)&pong, sizeof(he_msg_pong_t));
+  // Set DF flag for all ping/pong messages
+  uint32_t old_flags = conn->outside_write_flags;
+  conn->outside_write_flags = conn->outside_write_flags | HE_OUTSIDE_WRITE_DONT_FRAGMENT;
+
+  // Send it
+  he_return_code_t res = he_internal_send_message(conn, (uint8_t *)&pong, sizeof(he_msg_pong_t));
+
+  // Restore old flags
+  conn->outside_write_flags = old_flags;
+
+  return res;
 }
 
 he_return_code_t he_handle_msg_pong(he_conn_t *conn, uint8_t *packet, int length) {

--- a/src/he/plugin_chain.c
+++ b/src/he/plugin_chain.c
@@ -25,7 +25,7 @@ he_plugin_chain_t *he_plugin_create_chain(void) {
 }
 
 void he_plugin_destroy_chain(he_plugin_chain_t *chain) {
-  if (chain) {
+  if(chain) {
     he_plugin_destroy_chain(chain->next);
     he_free(chain);
   }

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -563,11 +563,21 @@ void he_ssl_ctx_set_outside_write_cb(he_ssl_ctx_t *ctx, he_outside_write_cb_t ou
   ctx->outside_write_cb = outside_write_cb;
 }
 
+void he_ssl_ctx_set_outside_write_ex_cb(he_ssl_ctx_t *ctx,
+                                        he_outside_write_ex_cb_t outside_write_ex_cb) {
+  // Return if ctx is null
+  if(!ctx) {
+    return;
+  }
+
+  ctx->outside_write_ex_cb = outside_write_ex_cb;
+}
+
 bool he_ssl_ctx_is_outside_write_cb_set(he_ssl_ctx_t *ctx) {
   if(!ctx) {
     return false;
   }
-  return ctx->outside_write_cb;
+  return ctx->outside_write_cb || ctx->outside_write_ex_cb;
 }
 
 void he_ssl_ctx_set_network_config_ipv4_cb(he_ssl_ctx_t *ctx,

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -342,6 +342,8 @@ bool he_ssl_ctx_is_inside_write_cb_set(he_ssl_ctx_t *ctx);
  * Linux this would usually be a UDP socket.
  */
 void he_ssl_ctx_set_outside_write_cb(he_ssl_ctx_t *ctx, he_outside_write_cb_t outside_write_cb);
+void he_ssl_ctx_set_outside_write_ex_cb(he_ssl_ctx_t *ctx,
+                                        he_outside_write_ex_cb_t outside_write_ex_cb);
 
 /**
  * @brief Called when the host application needs to deliver outside data to be processed by Helium

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -333,7 +333,8 @@ bool he_ssl_ctx_is_inside_write_cb_set(he_ssl_ctx_t *ctx);
 /**
  * @brief Sets the function that will be called when Helium needs to do an outside write.
  * @param ctx A pointer to a valid SSL context
- * @param outside_write_cb  The function to be called when Helium needs to do an outside write
+ * @param outside_write_cb The function to be called when Helium needs to do an outside write
+ * @deprecated Use `he_ssl_ctx_set_outside_write_ex_cb` instead.
  *
  * Helium is platform agnostic and as such does not handle its own I/O. This allows the developer
  * to hook up Helium using the most appropriate methods for their platform.
@@ -342,6 +343,18 @@ bool he_ssl_ctx_is_inside_write_cb_set(he_ssl_ctx_t *ctx);
  * Linux this would usually be a UDP socket.
  */
 void he_ssl_ctx_set_outside_write_cb(he_ssl_ctx_t *ctx, he_outside_write_cb_t outside_write_cb);
+
+/**
+ * @brief Sets the function that will be called when Helium needs to do an outside write.
+ * @param ctx A pointer to a valid SSL context
+ * @param outside_write_cb The function to be called when Helium needs to do an outside write
+ *
+ * Helium is platform agnostic and as such does not handle its own I/O. This allows the developer
+ * to hook up Helium using the most appropriate methods for their platform.
+ *
+ * Outside writes are triggered when encrypted packets need to be sent to the Helium server. On
+ * Linux this would usually be a UDP socket.
+ */
 void he_ssl_ctx_set_outside_write_ex_cb(he_ssl_ctx_t *ctx,
                                         he_outside_write_ex_cb_t outside_write_ex_cb);
 

--- a/src/he/wolf.c
+++ b/src/he/wolf.c
@@ -164,25 +164,22 @@ int he_wolf_dtls_write(WOLFSSL *ssl, char *buf, int sz, void *ctx) {
     return WOLFSSL_CBIO_ERR_GENERAL;
   }
 
-  // Call the write callback if set
-  if(conn->outside_write_cb || conn->outside_write_ex_cb) {
+  res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
+  if(res != HE_SUCCESS) {
+    return WOLFSSL_CBIO_ERR_GENERAL;
+  }
+
+  // If we're not yet connected, be aggressive and send two more packets. If aggressive mode
+  // is set, always be aggressive and send two more.
+  if(conn->state != HE_STATE_ONLINE || conn->use_aggressive_mode) {
     res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
     if(res != HE_SUCCESS) {
       return WOLFSSL_CBIO_ERR_GENERAL;
     }
 
-    // If we're not yet connected, be aggressive and send two more packets. If aggressive mode
-    // is set, always be aggressive and send two more.
-    if(conn->state != HE_STATE_ONLINE || conn->use_aggressive_mode) {
-      res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
-      if(res != HE_SUCCESS) {
-        return WOLFSSL_CBIO_ERR_GENERAL;
-      }
-
-      res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
-      if(res != HE_SUCCESS) {
-        return WOLFSSL_CBIO_ERR_GENERAL;
-      }
+    res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
+    if(res != HE_SUCCESS) {
+      return WOLFSSL_CBIO_ERR_GENERAL;
     }
   }
 
@@ -282,11 +279,9 @@ int he_wolf_tls_write(WOLFSSL *ssl, char *buf, int sz, void *ctx) {
   }
 
   // Call the write callback if set
-  if(conn->outside_write_cb || conn->outside_write_ex_cb) {
-    res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
-    if(res != HE_SUCCESS) {
-      return WOLFSSL_CBIO_ERR_GENERAL;
-    }
+  res = he_internal_conn_outside_write(conn, conn->write_buffer, post_plugin_length);
+  if(res != HE_SUCCESS) {
+    return WOLFSSL_CBIO_ERR_GENERAL;
   }
 
   // Return the size written

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -590,6 +590,10 @@ static int wolfSSL_write_ping_stub(WOLFSSL *ssl, const void *data, int sz) {
   TEST_ASSERT_EQUAL(0, ping->length);
   TEST_ASSERT_EQUAL(sizeof(he_msg_ping_t), sz);
 
+  // Check the outside_write_flags is set with DF flag
+  TEST_ASSERT_EQUAL(HE_OUTSIDE_WRITE_DONT_FRAGMENT,
+                    conn.outside_write_flags & HE_OUTSIDE_WRITE_DONT_FRAGMENT);
+
   return sz;
 }
 

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -371,7 +371,7 @@ void test_he_client_connect_fails_when_secure_renegotiation_is_not_available(voi
 
   wolfSSL_CTX_load_verify_buffer_ExpectAndReturn(my_ctx, fake_cert, sizeof(fake_cert),
                                                  SSL_FILETYPE_PEM, SSL_SUCCESS);
-  
+
   wolfSSL_CTX_SetMinVersion_ExpectAndReturn(my_ctx, WOLFSSL_DTLSV1_2, SSL_SUCCESS);
 
   // Set mock callbacks from our own wolf code
@@ -450,8 +450,11 @@ void test_he_server_connect_succeeds(void) {
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
 
-  wolfSSL_CTX_set_cipher_list_ExpectAndReturn(my_ctx, "TLS13-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305"
-                                                      ":TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384", SSL_SUCCESS);
+  wolfSSL_CTX_set_cipher_list_ExpectAndReturn(
+      my_ctx,
+      "TLS13-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305"
+      ":TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384",
+      SSL_SUCCESS);
 
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_dtls_read);
@@ -477,7 +480,8 @@ void test_he_server_connect_succeeds_streaming(void) {
   wolfSSL_CTX_use_PrivateKey_file_ExpectAndReturn(my_ctx, ctx3->server_key, SSL_FILETYPE_PEM,
                                                   SSL_SUCCESS);
 
-  wolfSSL_CTX_set_cipher_list_ExpectAndReturn(my_ctx, "TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256", SSL_SUCCESS);
+  wolfSSL_CTX_set_cipher_list_ExpectAndReturn(
+      my_ctx, "TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256", SSL_SUCCESS);
 
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_tls_read);
@@ -738,6 +742,13 @@ void test_is_set_outside_write_cb(void) {
   TEST_ASSERT_EQUAL(true, res2);
   bool res3 = he_ssl_ctx_is_outside_write_cb_set(NULL);
   TEST_ASSERT_EQUAL(false, res3);
+
+  // he_ssl_ctx_is_outside_write_cb_set should also return true
+  // when outside_write_ex_cb is set
+  ctx->outside_write_cb = NULL;
+  he_ssl_ctx_set_outside_write_ex_cb(ctx, write_cb_ex);
+  bool res4 = he_ssl_ctx_is_outside_write_cb_set(ctx);
+  TEST_ASSERT_EQUAL(true, res4);
 }
 
 void test_is_set_network_config_ipv4_cb(void) {
@@ -810,7 +821,7 @@ void test_use_pqc(void) {
   TEST_ASSERT_EQUAL(HE_SUCCESS, he_ssl_ctx_set_use_pqc(ctx, false));
   TEST_ASSERT_FALSE(ctx->use_pqc);
 }
-#endif // HE_NO_PQC
+#endif  // HE_NO_PQC
 
 void test_set_nudge_time_cb(void) {
   he_ssl_ctx_set_nudge_time_cb(ctx, nudge_time_cb);

--- a/test/he/test_wolf.c
+++ b/test/he/test_wolf.c
@@ -310,29 +310,13 @@ void test_internal_pkt_header_writer_pending_session(void) {
                            sizeof(conn->session_id));
 }
 
-void test_write_dont_explode_if_not_write_cb_set(void) {
+void test_write_should_return_err_if_no_write_cb_set(void) {
   // Unset the callback
   conn->outside_write_cb = NULL;
 
   int res1 = he_wolf_dtls_write(ssl, (char *)packet, test_packet_size, conn);
 
-  // Checks that the data written is what WolfSSL expects - Helium headers are extra and not covered
-  // here
-  TEST_ASSERT_EQUAL(test_packet_size, res1);
-
-  // Test we have a valid helium header
-  assert_standard_header(conn->write_buffer);
-  assert_standard_version(conn->write_buffer);
-  assert_standard_reserved_section(conn->write_buffer);
-
-  TEST_ASSERT_EQUAL(0x00, conn->write_buffer[4]);
-  TEST_ASSERT_EQUAL_MEMORY(&conn->session_id, &conn->write_buffer[8], sizeof(conn->session_id));
-
-  // Test packet is unchanged
-  TEST_ASSERT_EQUAL_MEMORY(packet, conn->write_buffer + sizeof(he_wire_hdr_t), test_packet_size);
-
-  // Test that the callback is set correctly
-  TEST_ASSERT_NULL(conn->outside_write_cb);
+  TEST_ASSERT_EQUAL(WOLFSSL_CBIO_ERR_GENERAL, res1);
 }
 
 void test_write_accepts_conn_version(void) {
@@ -552,16 +536,13 @@ void test_plugin_error_results_in_no_write_tls(void) {
   TEST_ASSERT_EQUAL(0, write_callback_count);
 }
 
-void test_tls_write_dont_explode_if_not_write_cb_set(void) {
+void test_tls_write_should_return_err_if_not_write_cb_set(void) {
   // Unset the callback
   conn->outside_write_cb = NULL;
 
   int res1 = he_wolf_tls_write(ssl, (char *)packet, test_packet_size, conn);
 
-  TEST_ASSERT_EQUAL(test_packet_size, res1);
-
-  // Test that the callback is set correctly
-  TEST_ASSERT_NULL(conn->outside_write_cb);
+  TEST_ASSERT_EQUAL(WOLFSSL_CBIO_ERR_GENERAL, res1);
 }
 
 void test_tls_write_outside_cb_cb_returns_failure(void) {

--- a/test/support/test_defs.h
+++ b/test/support/test_defs.h
@@ -38,6 +38,12 @@ he_return_code_t write_cb(he_conn_t *conn, uint8_t *packet, size_t length, void 
   return HE_SUCCESS;
 }
 
+he_return_code_t write_cb_ex(he_conn_t *conn, uint8_t *packet, size_t length, uint32_t flags,
+                             void *context) {
+  call_counter++;
+  return HE_SUCCESS;
+}
+
 he_return_code_t state_cb(he_conn_t *conn, he_conn_state_t new_state, void *context) {
   call_counter++;
   return HE_SUCCESS;
@@ -54,8 +60,7 @@ he_return_code_t network_config_ipv4_cb(he_conn_t *conn, he_network_config_ipv4_
   return HE_SUCCESS;
 }
 
-he_return_code_t server_config_cb(he_conn_t *conn, uint8_t *buffer, size_t length,
-                                  void *context) {
+he_return_code_t server_config_cb(he_conn_t *conn, uint8_t *buffer, size_t length, void *context) {
   call_counter++;
   return HE_SUCCESS;
 }


### PR DESCRIPTION
## Description
We want to set the DF flag on the IP packet header when sending out the Lightway ping/pong messages. To achieve this, we introduce a new `outside_write_ex_cb` callback which takes an extra `flags` argument. Client/Server implementations are recommended to provide `outside_write_ex_cb` instead of `outside_write_cb`, if the HE_OUTSIDE_WRITE_DONT_FRAGMENT flag is set, the `outside_write_ex_cb` function should set the `DF` (Don't Fragment) flag in the IP packet header.

This change is backward compatible, all existing client/server implementations which only set `outside_write_cb` callback will continue to work the same way as before. 

If `outside_write_ex_cb` callback is set, Lightway Core will use `outside_write_ex_cb` when writing outside packets, and Lightway Core will set HE_OUTSIDE_WRITE_DONT_FRAGMENT for ping/pong message.

## Motivation and Context
Ensure Ping/Pong messages are not fragmented, so that they could be used for PMTU Discovery.

## How Has This Been Tested?
Unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`