### PR TITLE
ci: build lightway-core for both bullseye and bookworm on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   earthly:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        distro: [bullseye, bookworm]
     env:
       FORCE_COLOR: 1
     steps:
@@ -26,7 +29,7 @@ jobs:
           fi
           git checkout -b "$branch" || true
       - name: Run build
-        run: earthly --ci +all
+        run: earthly --ci +all --distro=${{ matrix.distro }}
   linux:
     runs-on: ubuntu-22.04
     steps:

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,6 @@
 VERSION 0.7
-FROM --platform=linux/amd64 debian:bullseye-slim
+ARG distro=bullseye
+FROM --platform=linux/amd64 debian:$distro-slim
 WORKDIR /libhelium
 
 debian-deps:
@@ -8,7 +9,7 @@ debian-deps:
     # Not including colrm seems to give an error when configuring wolfssl
     RUN apt-get -y install --no-install-recommends bsdmainutils
     RUN gem install ceedling --no-user-install
-    RUN pip3 install gcovr
+    RUN apt-get -y install --no-install-recommends gcovr
 
 libhelium-deps:
     FROM +debian-deps

--- a/linux.yml
+++ b/linux.yml
@@ -33,7 +33,7 @@
         :source: $HE_WOLFSSL_SOURCE
         :tag: $HE_WOLFSSL_TAG
       :environment:
-        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_SPHINCS
+        - CFLAGS=-O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_SPHINCS -Wno-error=stringop-overflow
       :build:
         - git apply ../../wolfssl/0001-DoHelloVerifyRequest-only-do-DTLS-1.3-version-check.patch
         - git apply ../../wolfssl/0002-DTLS-1.3-move-state-machine-forward-when-HVR-receive.patch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an Earthly ARG `distro` to allow building Lightway Core for different debian distro.

Build lightway-core for both bullseye and bookworm on CI, as we're preparing to upgrade server to bookworm. The bullseye CI build will be removed later.

Workaround a WolfSSL compiling issue by suppressing a gcc 12 warning via `-Wno-error=stringop-overflow`.
See: https://bugs.launchpad.net/ubuntu/+source/gcc-12/+bug/2013140

## Motivation and Context
Maintenance.

## How Has This Been Tested?
CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`