### PR TITLE
Fix potential bugs in flow.c: he_conn_inside_packet_received

### DIFF
--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -47,6 +47,14 @@ he_return_code_t he_conn_inside_packet_received(he_conn_t *conn, uint8_t *packet
     return HE_ERR_PACKET_TOO_SMALL;
   }
 
+  // Find IP protocol from the first byte
+  int protocol = packet[0] >> 4;
+
+  // For now we only support IPv4
+  if(protocol != 4) {
+    return HE_ERR_UNSUPPORTED_PACKET_TYPE;
+  }
+
   // Return if the packet is larger than the MTU of a Helium tunnel
   // Note that we check both conditions here even though with the current implementation
   // HE_MAX_MTU is lower than the normal outside_mtu value and the current packet overhead
@@ -70,14 +78,6 @@ he_return_code_t he_conn_inside_packet_received(he_conn_t *conn, uint8_t *packet
   // Sanity-check length -- contract says that it can't be longer than length but just-in-case
   if(post_plugin_length > length) {
     return HE_ERR_FAILED;
-  }
-
-  // Find IP protocol from the first byte
-  int protocol = packet[0] >> 4;
-
-  // For now we only support IPv4
-  if(protocol != 4) {
-    return HE_ERR_UNSUPPORTED_PACKET_TYPE;
   }
 
   // We need just enough space for the max packet size plus its header

--- a/test/he/test_flow.c
+++ b/test/he/test_flow.c
@@ -130,7 +130,6 @@ void test_inside_pkt_received_too_large(void) {
 
 void test_inside_pkt_bad_packet(void) {
   conn->state = HE_STATE_ONLINE;
-  he_plugin_ingress_ExpectAnyArgsAndReturn(HE_SUCCESS);
   int res1 =
       he_conn_inside_packet_received(conn, bad_fake_ipv4_packet, sizeof(bad_fake_ipv4_packet));
   TEST_ASSERT_EQUAL(HE_ERR_UNSUPPORTED_PACKET_TYPE, res1);


### PR DESCRIPTION
## Description
There are potential bugs in the `he_conn_inside_packet_received` function when a Lightway plugin is used.

Bug 1: The function checks the ip packet type after the packet is already processed by the plugin. Since a plugin may modify the packet data in any way it wants, it's no guaranteed that the ipv4 header is still preserved.

## Motivation and Context
Fix potential issue when using Lightway with certain plugins.

## How Has This Been Tested?
Unit tested on CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`