### PR TITLE
LIT-135 Fixed a bug which causes unexpected fragments from server

### DIFF
--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -92,7 +92,7 @@ he_return_code_t he_conn_inside_packet_received(he_conn_t *conn, uint8_t *packet
   }
 
   // Check if we need fragment the packet
-  if(conn->connection_type == HE_CONNECTION_TYPE_STREAM || post_plugin_length < effective_pmtu) {
+  if(conn->connection_type == HE_CONNECTION_TYPE_STREAM || post_plugin_length <= effective_pmtu) {
     // Get the actual length after padding
     size_t actual_length = he_internal_calculate_data_packet_length(conn, post_plugin_length);
 

--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -34,6 +34,11 @@
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/settings.h>
 
+bool he_internal_flow_should_fragment(he_conn_t *conn, uint16_t effective_pmtu, uint16_t length) {
+  return conn->connection_type == HE_CONNECTION_TYPE_DATAGRAM &&
+         conn->pmtud_state == HE_PMTUD_STATE_SEARCH_COMPLETE && length > effective_pmtu;
+}
+
 he_return_code_t he_conn_inside_packet_received(he_conn_t *conn, uint8_t *packet, size_t length) {
   // Return if packet or conn is null
   if(!packet || !conn) {
@@ -92,7 +97,8 @@ he_return_code_t he_conn_inside_packet_received(he_conn_t *conn, uint8_t *packet
   }
 
   // Check if we need fragment the packet
-  if(conn->connection_type == HE_CONNECTION_TYPE_STREAM || post_plugin_length <= effective_pmtu) {
+  bool should_frag = he_internal_flow_should_fragment(conn, effective_pmtu, post_plugin_length);
+  if(!should_frag) {
     // Get the actual length after padding
     size_t actual_length = he_internal_calculate_data_packet_length(conn, post_plugin_length);
 

--- a/src/he/flow.h
+++ b/src/he/flow.h
@@ -78,4 +78,6 @@ he_return_code_t he_internal_flow_outside_stream_received(he_conn_t *conn, uint8
 he_return_code_t he_internal_flow_outside_data_verify_connection(he_conn_t *conn);
 he_return_code_t he_internal_flow_outside_data_handle_messages(he_conn_t *conn);
 
+bool he_internal_flow_should_fragment(he_conn_t *conn, uint16_t effective_pmtu, uint16_t length);
+
 #endif  // FLOW_H

--- a/test/he/test_flow.c
+++ b/test/he/test_flow.c
@@ -173,6 +173,25 @@ void test_inside_pkt_good_packet_with_legacy_behaviour(void) {
   TEST_ASSERT_EQUAL(HE_SUCCESS, res1);
 }
 
+void test_he_internal_flow_should_fragment(void) {
+  // Don't frag for Lightway TCP
+  conn->connection_type = HE_CONNECTION_TYPE_STREAM;
+  TEST_ASSERT_FALSE(he_internal_flow_should_fragment(conn, 1200, 1350));
+
+  // Don't frag if PMTUD search hasn't completed
+  conn->connection_type = HE_CONNECTION_TYPE_DATAGRAM;
+  conn->pmtud_state = HE_PMTUD_STATE_SEARCHING;
+  TEST_ASSERT_FALSE(he_internal_flow_should_fragment(conn, 1200, 1350));
+
+  // Don't frag if the packet length is exactly effective_pmtu
+  conn->connection_type = HE_CONNECTION_TYPE_DATAGRAM;
+  conn->pmtud_state = HE_PMTUD_STATE_SEARCH_COMPLETE;
+  TEST_ASSERT_FALSE(he_internal_flow_should_fragment(conn, 1200, 1200));
+
+  // Should frag if packet length is greater than effective_pmtu
+  TEST_ASSERT_TRUE(he_internal_flow_should_fragment(conn, 1200, 1201));
+}
+
 void test_inside_pkt_good_packet_clamp_mss_success(void) {
   conn->state = HE_STATE_ONLINE;
   conn->pmtud_state = HE_PMTUD_STATE_SEARCH_COMPLETE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A bug caused server sending fragmented packets when it shouldn't. The fixes are:

* Don't fragment if the inside packet size is exactly the same as the `effective_pmtu`
* Don't fragment if the pmtud search hasn't completed, which should effectively disable the fragment feature on the server side 

## Motivation and Context
Bug fix.

## How Has This Been Tested?
CI tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`