### PR TITLE
ios: disable inlining when compiling wolfSSL

### DIFF
--- a/ios/autotools-ios-helper.sh
+++ b/ios/autotools-ios-helper.sh
@@ -24,7 +24,7 @@ OQS_BUILD=${OQS_BUILD:-"$(pwd)/../liboqs/build_universal"}
 
 build() {
     # Compiler options
-    export OPT_FLAGS="-O3"
+    export OPT_FLAGS="-O3 -fno-inline"
     export MAKE_JOBS="$(/usr/sbin/sysctl -n hw.ncpu)"
 
     # WolfSSL + Helium


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes an issue with p256 and p256 adjacent algorithms.

This fix is a temporary one until a proper fix is implemented in wolfSSL.

## Motivation and Context
This fixes the issues on iOS

## How Has This Been Tested?
Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`