### PR TITLE
LIT-197 Make fragment table size configureable

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -1130,6 +1130,13 @@ he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled);
 #endif  // HE_NO_PQC
 
 /**
+ * @brief Sets the maximum number of entries the connection can use for reassembling fragments.
+ * @param max_frag_entries Max number of entries for fragment assembly.
+ * @return HE_SUCCESS if the value is set successfully.
+ */
+he_return_code_t he_ssl_ctx_set_max_frag_entries(he_ssl_ctx_t *ctx, size_t max_frag_entries);
+
+/**
  * D/TLS is a UDP based protocol and requires the application
  * (rather than the OS as with TCP) to keep track of the need to do
  * retransmits on packet loss.

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -145,15 +145,7 @@ he_conn_t *he_conn_create(void) {
 
 void he_conn_destroy(he_conn_t *conn) {
   if(conn) {
-    // Free up all cached fragments
-    for(size_t i = 0; i < (sizeof(conn->frag_table.entries) / sizeof(he_fragment_entry_t *)); i++) {
-      he_fragment_entry_t *entry = conn->frag_table.entries[i];
-      if(entry) {
-        he_fragment_entry_reset(entry);
-        he_free(entry);
-        conn->frag_table.entries[i] = NULL;
-      }
-    }
+    he_internal_fragment_table_destroy(conn->frag_table);
     wolfSSL_free(conn->wolf_ssl);
     he_free(conn);
   }
@@ -197,6 +189,9 @@ he_return_code_t he_internal_conn_configure(he_conn_t *conn, he_ssl_ctx_t *ctx) 
 
   // Initialize internal variables
   conn->ping_next_id = 1;
+
+  // Initialize the fragment table
+  conn->frag_table = he_internal_fragment_table_create();
 
   return HE_SUCCESS;
 }

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -191,8 +191,10 @@ he_return_code_t he_internal_conn_configure(he_conn_t *conn, he_ssl_ctx_t *ctx) 
   conn->ping_next_id = 1;
 
   // Initialize the fragment table
-  conn->frag_table = he_internal_fragment_table_create();
-
+  conn->frag_table = he_internal_fragment_table_create(ctx->max_frag_entries);
+  if(conn->frag_table == NULL) {
+    return HE_ERR_NO_MEMORY;
+  }
   return HE_SUCCESS;
 }
 

--- a/src/he/frag.c
+++ b/src/he/frag.c
@@ -185,21 +185,36 @@ he_return_code_t he_fragment_entry_update(he_fragment_entry_t *entry, uint8_t *d
   return HE_SUCCESS;
 }
 
-he_fragment_table_t *he_internal_fragment_table_create(void) {
-  return he_calloc(1, sizeof(he_fragment_table_t));
+he_fragment_table_t *he_internal_fragment_table_create(size_t num_entries) {
+  he_fragment_table_t *tbl = he_calloc(1, sizeof(he_fragment_table_t));
+  if(tbl == NULL) {
+    return NULL;
+  }
+  if(num_entries == 0) {
+    num_entries = MAX_FRAGMENT_ENTRIES;
+  }
+  tbl->entries = (he_fragment_entry_t **)he_calloc(num_entries, sizeof(he_fragment_entry_t *));
+  if(tbl->entries == NULL) {
+    // Not enough memory
+    he_free(tbl);
+    return NULL;
+  }
+  tbl->num_entries = num_entries;
+  return tbl;
 }
 
 he_fragment_entry_t *he_internal_fragment_table_find(he_fragment_table_t *tbl, uint16_t frag_id) {
   if(!tbl) {
     return NULL;
   }
-  he_fragment_entry_t *entry = tbl->entries[frag_id];
+  uint16_t idx = frag_id % tbl->num_entries;
+  he_fragment_entry_t *entry = tbl->entries[idx];
   if(entry == NULL) {
     // Fragment entry not found, create a new one
     entry = he_calloc(1, sizeof(he_fragment_entry_t));
     if(entry != NULL) {
       entry->timestamp = time(NULL);
-      tbl->entries[frag_id] = entry;
+      tbl->entries[idx] = entry;
     }
   }
   return entry;
@@ -209,11 +224,12 @@ void he_internal_fragment_table_delete(he_fragment_table_t *tbl, uint16_t frag_i
   if(!tbl) {
     return;
   }
-  he_fragment_entry_t *entry = tbl->entries[frag_id];
+  uint16_t idx = frag_id % tbl->num_entries;
+  he_fragment_entry_t *entry = tbl->entries[idx];
   if(entry) {
     he_fragment_entry_reset(entry);
     he_free(entry);
-    tbl->entries[frag_id] = NULL;
+    tbl->entries[idx] = NULL;
   }
 }
 
@@ -222,7 +238,7 @@ void he_internal_fragment_table_destroy(he_fragment_table_t *tbl) {
     return;
   }
   // Free up all cached fragments
-  for(size_t i = 0; i < (sizeof(tbl->entries) / sizeof(he_fragment_entry_t *)); i++) {
+  for(size_t i = 0; i < tbl->num_entries; i++) {
     he_fragment_entry_t *entry = tbl->entries[i];
     if(entry) {
       he_fragment_entry_reset(entry);
@@ -230,5 +246,6 @@ void he_internal_fragment_table_destroy(he_fragment_table_t *tbl) {
       tbl->entries[i] = NULL;
     }
   }
+  he_free(tbl->entries);
   he_free(tbl);
 }

--- a/src/he/frag.h
+++ b/src/he/frag.h
@@ -52,7 +52,8 @@ typedef struct he_fragment_entry {
 
 // Fragment table for reassembling fragments
 typedef struct he_fragment_table {
-  he_fragment_entry_t *entries[MAX_FRAGMENT_ENTRIES];
+  he_fragment_entry_t **entries;
+  size_t num_entries;
 } he_fragment_table_t;
 
 /**
@@ -88,11 +89,13 @@ int he_fragment_entry_update(he_fragment_entry_t *entry, uint8_t *data, uint16_t
 
 /**
  * @brief Create and initialize a new fragment table.
+ * @param num_entries Number of fragment entries can be used in the fragment table. If it's 0, the
+ * default value MAX_FRAGMENT_ENTRIES will be used.
  * @return Pointer to a he_fragment_table_t struct.
  * @note This function allocates memory, the caller must call `he_internal_fragment_table_destroy`
  * after use.
  */
-he_fragment_table_t *he_internal_fragment_table_create(void);
+he_fragment_table_t *he_internal_fragment_table_create(size_t num_entries);
 
 /**
  * @brief Find entry for the given fragment id.

--- a/src/he/frag.h
+++ b/src/he/frag.h
@@ -25,7 +25,35 @@
 #ifndef FRAG_H
 #define FRAG_H
 
-#include "he_internal.h"
+#include <stddef.h>
+#include <time.h>
+
+#define MAX_FRAGMENT_ENTRIES 65536
+
+// Forward declarations
+typedef struct he_conn he_conn_t;
+typedef struct he_fragment_entry_node he_fragment_entry_node_t;
+
+// Information of a fragment
+typedef struct he_fragment_entry_node {
+  uint16_t begin;
+  uint16_t end;
+  bool last_frag;
+  he_fragment_entry_node_t *next;
+} he_fragment_entry_node_t;
+
+// An entry of the fragment table
+typedef struct he_fragment_entry {
+  uint8_t data[HE_MAX_WIRE_MTU];
+  time_t timestamp;
+  // Linked list contains infomation of received fragments
+  he_fragment_entry_node_t *fragments;
+} he_fragment_entry_t;
+
+// Fragment table for reassembling fragments
+typedef struct he_fragment_table {
+  he_fragment_entry_t *entries[MAX_FRAGMENT_ENTRIES];
+} he_fragment_table_t;
 
 /**
  * @brief Fragment a packet and send it over the secured tunnel as multiple messages
@@ -57,5 +85,36 @@ void he_fragment_entry_reset(he_fragment_entry_t *entry);
  */
 int he_fragment_entry_update(he_fragment_entry_t *entry, uint8_t *data, uint16_t offset,
                              size_t length, uint8_t mf, bool *assembled);
+
+/**
+ * @brief Create and initialize a new fragment table.
+ * @return Pointer to a he_fragment_table_t struct.
+ * @note This function allocates memory, the caller must call `he_internal_fragment_table_destroy`
+ * after use.
+ */
+he_fragment_table_t *he_internal_fragment_table_create(void);
+
+/**
+ * @brief Find entry for the given fragment id.
+ * @param tbl Pointer to a valid he_fragment_table_t struct.
+ * @param frag_id Fragment Identifier
+ * @return Pointer to the fragment entry of the given id. It may return NULL if the function failed
+ * to allocate memory for a new entry.
+ * @note This function may allocate memory.
+ */
+he_fragment_entry_t *he_internal_fragment_table_find(he_fragment_table_t *tbl, uint16_t frag_id);
+
+/**
+ * @brief Delete entry from the fragment table.
+ * @param tbl Pointer to a valid he_fragment_table_t struct.
+ * @param frag_id Fragment Identifier
+ */
+void he_internal_fragment_table_delete(he_fragment_table_t *tbl, uint16_t frag_id);
+
+/**
+ * @brief Destroy the given `he_fragment_table` and free up all memory.
+ * @param tbl A pointer to a valid he_fragment_table struct.
+ */
+void he_internal_fragment_table_destroy(he_fragment_table_t *tbl);
 
 #endif  // FRAG_H

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -123,6 +123,9 @@ struct he_ssl_ctx {
   /// Supported versions for this context
   he_version_info_t minimum_supported_version;
   he_version_info_t maximum_supported_version;
+
+  /// Maximum Fragment Entries
+  size_t max_frag_entries;
 };
 
 typedef struct he_fragment_table he_fragment_table_t;

--- a/src/he/he_internal.h
+++ b/src/he/he_internal.h
@@ -37,7 +37,7 @@
 // Network headers
 #include "he_plugin.h"
 
-// PMTUD
+// Dynamic MTU
 #include "pmtud.h"
 
 // WolfSSL
@@ -125,28 +125,7 @@ struct he_ssl_ctx {
   he_version_info_t maximum_supported_version;
 };
 
-typedef struct he_fragment_entry_node he_fragment_entry_node_t;
-
-// Information of a fragment
-typedef struct he_fragment_entry_node {
-  uint16_t begin;
-  uint16_t end;
-  bool last_frag;
-  he_fragment_entry_node_t *next;
-} he_fragment_entry_node_t;
-
-// An entry of the fragment table
-typedef struct he_fragment_entry {
-  uint8_t data[HE_MAX_WIRE_MTU];
-  time_t timestamp;
-  // Linked list contains infomation of received fragments
-  he_fragment_entry_node_t *fragments;
-} he_fragment_entry_t;
-
-// Fragment table for reassembling fragments
-typedef struct he_fragment_table {
-  he_fragment_entry_t *entries[65536];
-} he_fragment_table_t;
+typedef struct he_fragment_table he_fragment_table_t;
 
 struct he_conn {
   /// Internal Structure Member for client/server determination
@@ -271,7 +250,7 @@ struct he_conn {
 
   // UDP Fragmentation
   uint16_t frag_next_id;
-  he_fragment_table_t frag_table;
+  he_fragment_table_t *frag_table;
 };
 
 struct he_plugin_chain {

--- a/src/he/msg_handlers.c
+++ b/src/he/msg_handlers.c
@@ -471,15 +471,9 @@ he_return_code_t he_handle_msg_data_with_frag(he_conn_t *conn, uint8_t *packet, 
   uint16_t frag_id = ntohs(pkt->id);
 
   // Look up in fragment table
-  he_fragment_entry_t *entry = conn->frag_table.entries[frag_id];
+  he_fragment_entry_t *entry = he_internal_fragment_table_find(conn->frag_table, frag_id);
   if(entry == NULL) {
-    // Fragment entry not found, create a new one
-    entry = he_calloc(1, sizeof(he_fragment_entry_t));
-    if(entry == NULL) {
-      return HE_ERR_NO_MEMORY;
-    }
-    entry->timestamp = time(NULL);
-    conn->frag_table.entries[frag_id] = entry;
+    return HE_ERR_NO_MEMORY;
   }
 
   // Check if the entry has expired
@@ -504,9 +498,7 @@ he_return_code_t he_handle_msg_data_with_frag(he_conn_t *conn, uint8_t *packet, 
     he_return_code_t rc = internal_handle_data(conn, entry->data, entry->fragments->end);
 
     // Cleanup the entry
-    he_fragment_entry_reset(entry);
-    he_free(entry);
-    conn->frag_table.entries[frag_id] = NULL;
+    he_internal_fragment_table_delete(conn->frag_table, frag_id);
 
     return rc;
   }

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -27,7 +27,7 @@
 #include <wolfssl/ssl.h>
 
 #include "wolf.h"
-
+#include "frag.h"
 #include "memory.h"
 
 he_return_code_t he_init() {
@@ -747,3 +747,14 @@ he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled) {
   return HE_SUCCESS;
 }
 #endif
+
+he_return_code_t he_ssl_ctx_set_max_frag_entries(he_ssl_ctx_t *ctx, size_t max_frag_entries) {
+  if(!ctx) {
+    return HE_ERR_NULL_POINTER;
+  }
+  if(max_frag_entries > MAX_FRAGMENT_ENTRIES) {
+    max_frag_entries = MAX_FRAGMENT_ENTRIES;
+  }
+  ctx->max_frag_entries = max_frag_entries;
+  return HE_SUCCESS;
+}

--- a/src/he/ssl_ctx.h
+++ b/src/he/ssl_ctx.h
@@ -544,4 +544,11 @@ he_return_code_t he_ssl_ctx_set_use_pqc(he_ssl_ctx_t *ctx, bool enabled);
 
 #endif  // HE_NO_PQC
 
+/**
+ * @brief Sets the maximum number of entries the connection can use for reassembling fragments.
+ * @param max_frag_entries Max number of entries for fragment assembly.
+ * @return HE_SUCCESS if the value is set successfully.
+ */
+he_return_code_t he_ssl_ctx_set_max_frag_entries(he_ssl_ctx_t *ctx, size_t max_frag_entries);
+
 #endif  // SSL_CTX_H

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -153,9 +153,7 @@ void test_conn_create_destroy(void) {
 
   test_conn->wolf_ssl = &wolf_ssl;
 
-  test_conn->frag_table.entries[0] = (he_fragment_entry_t *)calloc(1, sizeof(he_fragment_entry_t));
-  he_fragment_entry_reset_Expect(test_conn->frag_table.entries[0]);
-
+  he_internal_fragment_table_destroy_Expect(test_conn->frag_table);
   wolfSSL_free_Expect(&wolf_ssl);
   he_conn_destroy(test_conn);
 }
@@ -1238,6 +1236,8 @@ void test_he_conn_server_connect(void) {
   he_return_code_t res2 = he_conn_set_protocol_version(&conn, 0x00, 0x00);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 
+  he_internal_fragment_table_create_ExpectAndReturn(NULL);
+
   wolfSSL_new_ExpectAndReturn(ssl_ctx.wolf_ctx, conn.wolf_ssl);
   wolfSSL_dtls_set_using_nonblock_Expect(conn.wolf_ssl, 1);
   wolfSSL_dtls_set_mtu_ExpectAndReturn(conn.wolf_ssl, 1423, SSL_SUCCESS);
@@ -1263,6 +1263,8 @@ void test_he_conn_server_connect_dn_set(void) {
 
   he_return_code_t res2 = he_conn_set_protocol_version(&conn, 0x00, 0x00);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
+
+  he_internal_fragment_table_create_ExpectAndReturn(NULL);
 
   wolfSSL_new_ExpectAndReturn(ssl_ctx.wolf_ctx, conn.wolf_ssl);
   wolfSSL_dtls_set_using_nonblock_Expect(conn.wolf_ssl, 1);
@@ -1290,6 +1292,8 @@ void test_he_conn_server_connect_dn_set_fail(void) {
 
   he_return_code_t res2 = he_conn_set_protocol_version(&conn, 0x00, 0x00);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
+
+  he_internal_fragment_table_create_ExpectAndReturn(NULL);
 
   wolfSSL_new_ExpectAndReturn(ssl_ctx.wolf_ctx, conn.wolf_ssl);
   wolfSSL_dtls_set_using_nonblock_Expect(conn.wolf_ssl, 1);
@@ -1501,6 +1505,8 @@ void test_he_internal_conn_configure_no_version(void) {
   ssl_ctx.pmtud_state_change_cb = (he_pmtud_state_change_cb_t)0x11;
 
   memset(&ssl_ctx.wolf_rng, 1, sizeof(WC_RNG));
+
+  he_internal_fragment_table_create_ExpectAndReturn(NULL);
 
   he_return_code_t res = he_internal_conn_configure(&conn, &ssl_ctx);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -47,6 +47,7 @@ he_ssl_ctx_t ssl_ctx;
 he_conn_t conn;
 he_return_code_t ret;
 WOLFSSL wolf_ssl;
+he_fragment_table_t frag_table;
 
 void setUp(void) {
   conn.wolf_ssl = &wolf_ssl;
@@ -54,10 +55,9 @@ void setUp(void) {
 
 void tearDown(void) {
   memset(&ssl_ctx, 0, sizeof(he_ssl_ctx_t));
-
   memset(&conn, 0, sizeof(he_conn_t));
-
   memset(&wolf_ssl, 0, sizeof(WOLFSSL));
+  memset(&frag_table, 0, sizeof(he_fragment_table_t));
   call_counter = 0;
 }
 
@@ -1236,7 +1236,7 @@ void test_he_conn_server_connect(void) {
   he_return_code_t res2 = he_conn_set_protocol_version(&conn, 0x00, 0x00);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 
-  he_internal_fragment_table_create_ExpectAndReturn(NULL);
+  he_internal_fragment_table_create_ExpectAndReturn(ssl_ctx.max_frag_entries, &frag_table);
 
   wolfSSL_new_ExpectAndReturn(ssl_ctx.wolf_ctx, conn.wolf_ssl);
   wolfSSL_dtls_set_using_nonblock_Expect(conn.wolf_ssl, 1);
@@ -1264,7 +1264,7 @@ void test_he_conn_server_connect_dn_set(void) {
   he_return_code_t res2 = he_conn_set_protocol_version(&conn, 0x00, 0x00);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 
-  he_internal_fragment_table_create_ExpectAndReturn(NULL);
+  he_internal_fragment_table_create_ExpectAndReturn(ssl_ctx.max_frag_entries, &frag_table);
 
   wolfSSL_new_ExpectAndReturn(ssl_ctx.wolf_ctx, conn.wolf_ssl);
   wolfSSL_dtls_set_using_nonblock_Expect(conn.wolf_ssl, 1);
@@ -1293,7 +1293,7 @@ void test_he_conn_server_connect_dn_set_fail(void) {
   he_return_code_t res2 = he_conn_set_protocol_version(&conn, 0x00, 0x00);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res2);
 
-  he_internal_fragment_table_create_ExpectAndReturn(NULL);
+  he_internal_fragment_table_create_ExpectAndReturn(ssl_ctx.max_frag_entries, &frag_table);
 
   wolfSSL_new_ExpectAndReturn(ssl_ctx.wolf_ctx, conn.wolf_ssl);
   wolfSSL_dtls_set_using_nonblock_Expect(conn.wolf_ssl, 1);
@@ -1503,10 +1503,10 @@ void test_he_internal_conn_configure_no_version(void) {
   ssl_ctx.populate_network_config_ipv4_cb = (he_populate_network_config_ipv4_cb_t)0x9;
   ssl_ctx.pmtud_time_cb = (he_pmtud_time_cb_t)0x10;
   ssl_ctx.pmtud_state_change_cb = (he_pmtud_state_change_cb_t)0x11;
-
+  ssl_ctx.max_frag_entries = 0x12;
   memset(&ssl_ctx.wolf_rng, 1, sizeof(WC_RNG));
 
-  he_internal_fragment_table_create_ExpectAndReturn(NULL);
+  he_internal_fragment_table_create_ExpectAndReturn(ssl_ctx.max_frag_entries, &frag_table);
 
   he_return_code_t res = he_internal_conn_configure(&conn, &ssl_ctx);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);

--- a/test/he/test_conn_connect.c
+++ b/test/he/test_conn_connect.c
@@ -33,12 +33,12 @@
 #include "config.h"
 #include "core.h"
 #include "memory.h"
+#include "frag.h"
 
 // Internal Mocks
 #include "mock_wolf.h"
 #include "mock_ssl_ctx.h"
 #include "mock_fake_dispatch.h"
-#include "mock_frag.h"
 #include "mock_pmtud.h"
 
 // External Mocks

--- a/test/he/test_frag.c
+++ b/test/he/test_frag.c
@@ -101,3 +101,36 @@ void test_frag_and_send_message(void) {
   TEST_ASSERT_EQUAL(1, conn.frag_next_id);
   TEST_ASSERT_EQUAL(sizeof(he_msg_hdr_t) + 6, sizeof(he_msg_data_frag_t));
 }
+
+void test_he_internal_fragment_table_create(void) {
+  he_fragment_table_t *tbl = he_internal_fragment_table_create();
+  TEST_ASSERT_NOT_NULL(tbl);
+  TEST_ASSERT_EQUAL(sizeof(he_fragment_entry_t *) * MAX_FRAGMENT_ENTRIES, sizeof(tbl->entries));
+}
+
+void test_he_internal_fragment_table_destroy(void) {
+  he_fragment_table_t *tbl = he_internal_fragment_table_create();
+  TEST_ASSERT_NOT_NULL(tbl);
+
+  for(size_t i = 0; i < MAX_FRAGMENT_ENTRIES; i++) {
+    TEST_ASSERT_NOT_NULL(he_internal_fragment_table_find(tbl, i));
+  }
+
+  he_internal_fragment_table_destroy(tbl);
+}
+
+void test_he_internal_fragment_table_delete(void) {
+  he_fragment_table_t *tbl = he_internal_fragment_table_create();
+  TEST_ASSERT_NOT_NULL(tbl);
+
+  for(size_t i = 0; i < MAX_FRAGMENT_ENTRIES; i++) {
+    TEST_ASSERT_NOT_NULL(he_internal_fragment_table_find(tbl, i));
+  }
+
+  // Delete random entry
+  uint16_t frag_id = rand() % MAX_FRAGMENT_ENTRIES;
+  he_internal_fragment_table_delete(tbl, frag_id);
+  TEST_ASSERT_NULL(tbl->entries[frag_id]);
+
+  he_internal_fragment_table_destroy(tbl);
+}

--- a/test/he/test_frag.c
+++ b/test/he/test_frag.c
@@ -103,13 +103,34 @@ void test_frag_and_send_message(void) {
 }
 
 void test_he_internal_fragment_table_create(void) {
-  he_fragment_table_t *tbl = he_internal_fragment_table_create();
+  he_fragment_table_t *tbl = he_internal_fragment_table_create(0);
   TEST_ASSERT_NOT_NULL(tbl);
-  TEST_ASSERT_EQUAL(sizeof(he_fragment_entry_t *) * MAX_FRAGMENT_ENTRIES, sizeof(tbl->entries));
+  TEST_ASSERT_NOT_NULL(tbl->entries);
+  TEST_ASSERT_EQUAL(sizeof(he_fragment_entry_t **), sizeof(tbl->entries));
+  TEST_ASSERT_EQUAL(MAX_FRAGMENT_ENTRIES, tbl->num_entries);
+}
+
+void test_he_internal_fragment_table_create_with_custom_num_entries(void) {
+  he_fragment_table_t *tbl = he_internal_fragment_table_create(4192);
+  TEST_ASSERT_NOT_NULL(tbl);
+  TEST_ASSERT_NOT_NULL(tbl->entries);
+  TEST_ASSERT_EQUAL(sizeof(he_fragment_entry_t **), sizeof(tbl->entries));
+  TEST_ASSERT_EQUAL(4192, tbl->num_entries);
 }
 
 void test_he_internal_fragment_table_destroy(void) {
-  he_fragment_table_t *tbl = he_internal_fragment_table_create();
+  he_fragment_table_t *tbl = he_internal_fragment_table_create(0);
+  TEST_ASSERT_NOT_NULL(tbl);
+
+  for(size_t i = 0; i < MAX_FRAGMENT_ENTRIES; i++) {
+    TEST_ASSERT_NOT_NULL(he_internal_fragment_table_find(tbl, i));
+  }
+
+  he_internal_fragment_table_destroy(tbl);
+}
+
+void test_he_internal_fragment_table_destroy_custom_num_entries(void) {
+  he_fragment_table_t *tbl = he_internal_fragment_table_create(4096);
   TEST_ASSERT_NOT_NULL(tbl);
 
   for(size_t i = 0; i < MAX_FRAGMENT_ENTRIES; i++) {
@@ -120,17 +141,34 @@ void test_he_internal_fragment_table_destroy(void) {
 }
 
 void test_he_internal_fragment_table_delete(void) {
-  he_fragment_table_t *tbl = he_internal_fragment_table_create();
+  he_fragment_table_t *tbl = he_internal_fragment_table_create(0);
   TEST_ASSERT_NOT_NULL(tbl);
 
   for(size_t i = 0; i < MAX_FRAGMENT_ENTRIES; i++) {
     TEST_ASSERT_NOT_NULL(he_internal_fragment_table_find(tbl, i));
   }
 
-  // Delete random entry
-  uint16_t frag_id = rand() % MAX_FRAGMENT_ENTRIES;
-  he_internal_fragment_table_delete(tbl, frag_id);
-  TEST_ASSERT_NULL(tbl->entries[frag_id]);
+  // Delete random entries
+  for(size_t i = 0; i < 1000; i++) {
+    uint16_t frag_id = rand() % MAX_FRAGMENT_ENTRIES;
+    he_internal_fragment_table_delete(tbl, frag_id);
+    TEST_ASSERT_NULL(tbl->entries[frag_id]);
+  }
+  he_internal_fragment_table_destroy(tbl);
+}
 
+void test_he_internal_fragment_table_find(void) {
+  he_fragment_table_t *tbl = he_internal_fragment_table_create(97);
+  TEST_ASSERT_NOT_NULL(tbl);
+  TEST_ASSERT_NOT_NULL(tbl->entries);
+  TEST_ASSERT_EQUAL(97, tbl->num_entries);
+
+  for(size_t i = 0; i < MAX_FRAGMENT_ENTRIES; i++) {
+    he_fragment_entry_t *entry = he_internal_fragment_table_find(tbl, i);
+    TEST_ASSERT_NOT_NULL(entry);
+    TEST_ASSERT_EQUAL_PTR(tbl->entries[i % tbl->num_entries], entry);
+  }
+
+  // Clean up
   he_internal_fragment_table_destroy(tbl);
 }

--- a/test/he/test_msg_handlers.c
+++ b/test/he/test_msg_handlers.c
@@ -1116,12 +1116,13 @@ static size_t make_fragment(uint8_t *buffer, uint16_t id, uint16_t offset, uint1
 
 void test_msg_data_frag_cache_new_fragment(void) {
   conn->state = HE_STATE_ONLINE;
+  conn->frag_table = he_internal_fragment_table_create();
 
   size_t length = make_fragment(empty_data, 123, 512, 512, 1);
   ret = he_handle_msg_data_with_frag(conn, empty_data, length);
   TEST_ASSERT_EQUAL(HE_SUCCESS, ret);
 
-  he_fragment_entry_t *entry = conn->frag_table.entries[123];
+  he_fragment_entry_t *entry = conn->frag_table->entries[123];
   TEST_ASSERT_NOT_NULL(entry);
   TEST_ASSERT_GREATER_OR_EQUAL(0, entry->timestamp);
   TEST_ASSERT_NOT_NULL(entry->fragments);
@@ -1133,6 +1134,7 @@ void test_msg_data_frag_cache_new_fragment(void) {
 
 void test_msg_data_frag_reassemble_full_packet(void) {
   conn->state = HE_STATE_ONLINE;
+  conn->frag_table = he_internal_fragment_table_create();
 
   // Received the 2nd fragment
   size_t len1 = make_fragment(empty_data, 123, 512, 512, 1);
@@ -1152,12 +1154,13 @@ void test_msg_data_frag_reassemble_full_packet(void) {
   TEST_ASSERT_EQUAL(HE_SUCCESS, ret);
 
   // Entry for the fragment id should be removed
-  he_fragment_entry_t *entry = conn->frag_table.entries[123];
+  he_fragment_entry_t *entry = conn->frag_table->entries[123];
   TEST_ASSERT_NULL(entry);
 }
 
 void test_msg_data_frag_overlap_fragments(void) {
   conn->state = HE_STATE_ONLINE;
+  conn->frag_table = he_internal_fragment_table_create();
 
   // Received the 2nd fragment
   size_t len1 = make_fragment(empty_data, 123, 512, 512, 1);

--- a/test/he/test_msg_handlers.c
+++ b/test/he/test_msg_handlers.c
@@ -1116,7 +1116,7 @@ static size_t make_fragment(uint8_t *buffer, uint16_t id, uint16_t offset, uint1
 
 void test_msg_data_frag_cache_new_fragment(void) {
   conn->state = HE_STATE_ONLINE;
-  conn->frag_table = he_internal_fragment_table_create();
+  conn->frag_table = he_internal_fragment_table_create(0);
 
   size_t length = make_fragment(empty_data, 123, 512, 512, 1);
   ret = he_handle_msg_data_with_frag(conn, empty_data, length);
@@ -1134,7 +1134,7 @@ void test_msg_data_frag_cache_new_fragment(void) {
 
 void test_msg_data_frag_reassemble_full_packet(void) {
   conn->state = HE_STATE_ONLINE;
-  conn->frag_table = he_internal_fragment_table_create();
+  conn->frag_table = he_internal_fragment_table_create(0);
 
   // Received the 2nd fragment
   size_t len1 = make_fragment(empty_data, 123, 512, 512, 1);
@@ -1160,7 +1160,7 @@ void test_msg_data_frag_reassemble_full_packet(void) {
 
 void test_msg_data_frag_overlap_fragments(void) {
   conn->state = HE_STATE_ONLINE;
-  conn->frag_table = he_internal_fragment_table_create();
+  conn->frag_table = he_internal_fragment_table_create(0);
 
   // Received the 2nd fragment
   size_t len1 = make_fragment(empty_data, 123, 512, 512, 1);

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -29,6 +29,7 @@
 // Direct Includes for Utility Functions
 #include "config.h"
 #include "memory.h"
+
 #include <wolfssl/error-ssl.h>
 
 // Internal Mocks
@@ -1012,4 +1013,21 @@ void test_he_ssl_ctx_start_server_ctx_null(void) {
 void test_he_ssl_ctx_start_ctx_null(void) {
   he_return_code_t res = he_ssl_ctx_start(NULL);
   TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
+}
+
+void test_he_ssl_ctx_set_max_frag_entries_null(void) {
+  he_return_code_t res = he_ssl_ctx_set_max_frag_entries(NULL, 42);
+  TEST_ASSERT_EQUAL(HE_ERR_NULL_POINTER, res);
+}
+
+void test_he_ssl_ctx_set_max_frag_entries_success(void) {
+  he_return_code_t res = he_ssl_ctx_set_max_frag_entries(ctx, 4192);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+  TEST_ASSERT_EQUAL(4192, ctx->max_frag_entries);
+}
+
+void test_he_ssl_ctx_set_max_frag_entries_large_number(void) {
+  he_return_code_t res = he_ssl_ctx_set_max_frag_entries(ctx, 1024768);
+  TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+  TEST_ASSERT_EQUAL(65536, ctx->max_frag_entries);
 }


### PR DESCRIPTION
## Description
Added a new API to allow implementation customise the fragmentation table size.

## Motivation and Context
Reduce memory usage on certain devices.

## How Has This Been Tested?
Unit tested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`