### PR TITLE
LIT-166: on error retry pmtu check after 1 minute

### DIFF
--- a/src/he/pmtud.h
+++ b/src/he/pmtud.h
@@ -49,6 +49,9 @@
 /// The minimal number of bytes to increase for the next PROBED_SIZE
 #define PMTUD_PROBE_SMALL_STEP 8
 
+/// The default timeout for retrying a failed PMTUD probe
+#define PMTUD_ERROR_RETRY_TIMEOUT_MS (60 * 1000)
+
 // Internal functions for PMTUD
 
 /**
@@ -136,5 +139,16 @@ he_return_code_t he_internal_pmtud_search_completed(he_conn_t *conn);
  * @note This function triggers a pmtud_state_change_cb callback to enter the BASE state.
  */
 he_return_code_t he_internal_pmtud_blackhole_detected(he_conn_t *conn);
+
+/**
+ * @brief Called when we want to retry probing
+ * @param conn A pointer to a valid connection conn
+ * @param delay_ms Delay in milliseconds to retry probing
+ * @return HE_SUCCESS if the operation succeeds. HE_ERR_PMTUD_CALLBACKS_NOT_SET if PMTUD callbacks
+ * are not set. Else it is the result of a pmtud_time_cb call.
+ * @note This function will also trigger a pmtud_time_cb callback to start the probe after the
+ * specified delay.
+ */
+he_return_code_t he_internal_pmtud_retry_probe(he_conn_t *conn, int delay_ms);
 
 #endif  // PMTUD_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Retry pmtu check after a minute when the pmtud state goes to `error`

## Motivation and Context
Ensures the pmtud state is not stuck in error

## How Has This Been Tested?
CI Tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`