### PR TITLE
conn: fix computation for frag table size

### DIFF
--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -146,7 +146,7 @@ he_conn_t *he_conn_create(void) {
 void he_conn_destroy(he_conn_t *conn) {
   if(conn) {
     // Free up all cached fragments
-    for(size_t i = 0; i < sizeof(conn->frag_table.entries) / sizeof(he_fragment_entry_t); i++) {
+    for(size_t i = 0; i < (sizeof(conn->frag_table.entries) / sizeof(he_fragment_entry_t *)); i++) {
       he_fragment_entry_t *entry = conn->frag_table.entries[i];
       if(entry) {
         he_fragment_entry_reset(entry);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The current computation undercounts the frag table size.

## Motivation and Context
Currently we only free 300-ish entries

## How Has This Been Tested?
This computation is easily checked with IDE tooling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`