### PR TITLE
LIT-279 conn: fix missing renegotiation events for dtls 1.3 and tls 1.3 connections

### DIFF
--- a/src/he/flow.c
+++ b/src/he/flow.c
@@ -100,8 +100,8 @@ he_return_code_t he_conn_inside_packet_received(he_conn_t *conn, uint8_t *packet
   bool should_frag = he_internal_flow_should_fragment(conn, effective_pmtu, post_plugin_length);
   if(!should_frag) {
     // Packet will not fit our buffer
-    if (post_plugin_length + sizeof(he_msg_data_t) > HE_MAX_WIRE_MTU) {
-     return HE_ERR_FAILED;
+    if(post_plugin_length + sizeof(he_msg_data_t) > HE_MAX_WIRE_MTU) {
+      return HE_ERR_FAILED;
     }
 
     // Get the actual length after padding
@@ -478,25 +478,25 @@ he_return_code_t he_internal_flow_outside_data_handle_messages(he_conn_t *conn) 
     he_internal_renegotiate_ssl(conn);
   }
 
-  // D/TLS Renegotiation and Timeout updates`
-  if(conn->connection_type == HE_CONNECTION_TYPE_DATAGRAM) {
+  // D/TLS Renegotiation and timeout updates
+  if(conn->renegotiation_in_progress) {
     int resp_pending = 0;
 
-    // wolfSSL_version currently doesn't recognize DTLS 1.3. Needs fixing.
     if(wolfSSL_version(conn->wolf_ssl) == DTLS1_2_VERSION) {
+      // DTLS 1.2
       resp_pending = wolfSSL_SSL_renegotiate_pending(conn->wolf_ssl);
     } else {
+      // D/TLS 1.3
       if(wolfSSL_key_update_response(conn->wolf_ssl, &resp_pending) != 0) {
         return HE_ERR_SSL_ERROR;
       }
     }
 
     // Check for renegotiation_in_progress
-    bool temp_renegotiation_in_progress = resp_pending;
-    if(conn->renegotiation_in_progress && !temp_renegotiation_in_progress) {
+    if(!resp_pending) {
       he_internal_generate_event(conn, HE_EVENT_SECURE_RENEGOTIATION_COMPLETED);
     }
-    conn->renegotiation_in_progress = temp_renegotiation_in_progress;
+    conn->renegotiation_in_progress = resp_pending;
 
     // Update the timeout
     he_internal_update_timeout(conn);

--- a/test/he/test_conn.c
+++ b/test/he/test_conn.c
@@ -1124,7 +1124,10 @@ void test_he_internal_renegotiate_ssl_already_renegotiating(void) {
 
   he_return_code_t res = he_internal_renegotiate_ssl(&conn);
   TEST_ASSERT_EQUAL(HE_SUCCESS, res);
+
+  // he_internal_renegotiate_ssl should reset renegotiation_due and return immediately
   TEST_ASSERT_FALSE(conn.renegotiation_due);
+  TEST_ASSERT_TRUE(conn.renegotiation_in_progress);
 }
 
 void test_he_internal_renegotiate_dtls_1_2(void) {


### PR DESCRIPTION
## Description
Lightway Core should generate both a `HE_EVENT_SECURE_RENEGOTIATION_STARTED` and a `HE_EVENT_SECURE_RENEGOTIATION_COMPLETED` events when doing secure renegotiation. 

When adding DTLS v1.3 support in PR https://github.com/expressvpn/lightway-core/pull/76, the behaviour was accidentally broken and only a `HE_EVENT_SECURE_RENEGOTIATION_COMPLETED` event was generated if the connection is using DTLS v1.3.

This PR introduced a behaviour change to TLS 1.3 that generates HE_EVENT_SECURE_RENEGOTIATION_STARTED & HE_EVENT_SECURE_RENEGOTIATION_COMPLETED events when rekeying. The purpose is to make the rekeying activity explicit (e.g. monitoring in metrics) and consistent with DTLS. It's not perfect as the "key renegotiation" and "key update" are technically two different implementation in the RFC specs, but we choose to use the old event names to maintain backward compatibility.

## Motivation and Context
This PR fixed the bug and makes the behaviour consistent between DTLS 1.2 and D/TLS 1.3.

## How Has This Been Tested?
CI tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`