### PR TITLE
readme: fix pre-commit link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ in the source code.
 
 == Development Environment
 
-This project uses [pre-commit](https://pre-commit.com/) to enforce code standards.
+This project uses https://pre-commit.com/[pre-commit] to enforce code standards.
 
 To install pre-commit, run: `earthly +install-precommit`.
 


### PR DESCRIPTION
## Description
Fixed the link to pre-commit.com as it was in Markdown form; the README is in adoc.

## Motivation and Context
It's nice to be able to click on links.

## How Has This Been Tested?
I clicked Preview. It looked 👌 to me!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`