### PR TITLE
Define CODEOWNERS as a Github team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global rule:
-*                         @expressvpn-pete-m @expressvpn-tom-l @expressvpn-andre-l @kp-mariappan-ramasamy @xv-ian-c @xv-thomas-leong
+*                         @expressvpn/expressvpn-lightway-codeowners


### PR DESCRIPTION
This simplifies management of permissions for ExpressVPN team members, as we can use this Github team across multiple repos as a single source of truth.

