### PR TITLE
CVPN-748 Enhance PMTUD Stability

### DIFF
--- a/src/he/pmtud.h
+++ b/src/he/pmtud.h
@@ -41,7 +41,7 @@
    HE_WOLF_MAX_HEADER_SIZE - sizeof(he_msg_data_t))
 
 /// The initial PMTU the discovery process will attempt to use first
-#define INITIAL_PLPMTU 1200
+#define INITIAL_PLPMTU 1250
 
 /// The default timeout for waiting for an acknowledgement to a probe packet, in milliseconds.
 #define PMTUD_PROBE_TIMEOUT_MS 5000


### PR DESCRIPTION
RFC 8899 recommends the base PLPMTU to be 1200, but in our tests we found 1250 is better in terms of speed and stability. This change is likely to have effect only on networks with small MTUs.

## Description

Changed BASE_PLPMTU from 1200 to 1250.

## How Has This Been Tested?

CI tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`