### PR TITLE
CVPN-934 Fix Apple CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run build
         run: CC="riscv64-linux-gnu-gcc" ceedling project:linux_riscv64 verbosity[4] release
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Install Ceedling

--- a/ios/Lightway/build-xcframework.sh
+++ b/ios/Lightway/build-xcframework.sh
@@ -4,14 +4,14 @@
 # iOS Device
 xcodebuild archive \
     -scheme Lightway \
-    -archivePath "./build/ios.xcarchive" \
+    -archivePath "./Build/ios.xcarchive" \
     -sdk iphoneos \
     SKIP_INSTALL=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO PLATFORM=universal
 
 # iOS Sim
 xcodebuild archive \
     -scheme Lightway \
-    -archivePath "./build/ios_sim.xcarchive" \
+    -archivePath "./Build/ios_sim.xcarchive" \
     -sdk iphonesimulator \
     SKIP_INSTALL=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO PLATFORM=universal
 


### PR DESCRIPTION
Steps in Github Actions recently began failing, one for iOS due to a case mismatch in a build script, and one for macOS due to Github changing its runners for `macos-latest` from x86 to arm64, conflicting with our build script.

## Description
Two changes:
- Change `macos-latest` to `macos-13` to use x86 hardware for our x86 build script
- Correct case mismatch in iOS build script

## Motivation and Context
See [link 1](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) and [link 2](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) for details on recent changes to Github runners.

## How Has This Been Tested?
Verify Github Actions completes successfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix, CI-only (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`