### PR TITLE
utils: add helper function he_safe_strncpy

### DIFF
--- a/src/he/utils.c
+++ b/src/he/utils.c
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include <assert.h>
 
 #define DEFCASE(X) \
   case X:          \
@@ -118,3 +119,11 @@ const char *he_pmtud_state_name(he_pmtud_state_t state) {
 }
 
 #undef DEFCASE
+
+char *he_safe_strncpy(char *dst, const char *src, size_t dst_size) {
+  assert(NULL != dst && NULL != src && 0 != dst_size);
+
+  char *res = strncpy(dst, src, dst_size - 1);
+  dst[dst_size - 1] = '\0';
+  return res;
+}

--- a/src/he/utils.h
+++ b/src/he/utils.h
@@ -57,4 +57,15 @@ const char *he_connection_protocol_name(he_connection_protocol_t protocol);
  */
 const char *he_pmtud_state_name(he_pmtud_state_t state);
 
+/**
+ * @brief Safe version of strncpy
+ * strncpy has a pitfall that `dst` will not be null terminated if there is no null byte
+ * in the first `dst_size` bytes of the array pointed to by `src`
+ * This function is a wrapper over strncpy which adds null byte as the last byte
+ * @param dst Pointer to the destination char array
+ * @param src Pointer to the source char array
+ * @param dst_size size of the destination char array
+ */
+char *he_safe_strncpy(char *dst, const char *src, size_t dst_size);
+
 #endif  // UTILS_H

--- a/test/he/test_utils.c
+++ b/test/he/test_utils.c
@@ -148,3 +148,36 @@ void test_he_connection_protocol_name(void) {
     TEST_ASSERT_EQUAL_STRING(cases[i].protocol_name, state);
   }
 }
+
+const char src[10] = "123456789";
+
+void test_he_safe_strncpy(void) {
+  TEST_ASSERT_EQUAL(10, sizeof(src));
+  TEST_ASSERT_EQUAL(9, strlen(src));
+
+  char dst[10];
+  TEST_ASSERT_EQUAL(dst, he_safe_strncpy(dst, src, sizeof(dst)));
+  TEST_ASSERT_EQUAL(dst[10 - 1], '\0');
+  TEST_ASSERT_EQUAL_INT(0, strcmp(dst, "123456789"));
+}
+
+void test_he_safe_strncpy_bigger_dst(void) {
+  char bigger_dst[15];
+  TEST_ASSERT_EQUAL(bigger_dst, he_safe_strncpy(bigger_dst, src, sizeof(bigger_dst)));
+  TEST_ASSERT_EQUAL(bigger_dst[15 - 1], '\0');
+  TEST_ASSERT_EQUAL_INT(0, strcmp(bigger_dst, "123456789"));
+}
+
+void test_he_safe_strncpy_smaller_dst(void) {
+  char smaller_dst[5];
+  TEST_ASSERT_EQUAL(smaller_dst, he_safe_strncpy(smaller_dst, src, sizeof(smaller_dst)));
+  TEST_ASSERT_EQUAL(smaller_dst[5 - 1], '\0');
+  TEST_ASSERT_EQUAL_INT(0, strcmp(smaller_dst, "1234"));
+}
+
+void test_he_safe_strncpy_boundary_check(void) {
+  char overflow_dst[9];
+  TEST_ASSERT_EQUAL(overflow_dst, he_safe_strncpy(overflow_dst, src, sizeof(overflow_dst)));
+  TEST_ASSERT_EQUAL(overflow_dst[9 - 1], '\0');
+  TEST_ASSERT_EQUAL_INT(0, strcmp(overflow_dst, "12345678"));
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adding a helper function to help perform strncpy and null termination in one go.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`strncpy` has a pitfall that `dst` will not be null terminated if there is no null byte in the first `dst_size` bytes of the array pointed to by `src`. Therefore, this PR is adding a helper function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI Tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`