### PR TITLE
public-header: Add helper function he_safe_strncpy

### DIFF
--- a/public/he.h
+++ b/public/he.h
@@ -1840,4 +1840,15 @@ const char *he_connection_protocol_name(he_connection_protocol_t protocol);
  */
 const char *he_pmtud_state_name(he_pmtud_state_t state);
 
+/**
+ * @brief Safe version of strncpy
+ * strncpy has a pitfall that `dst` will not be null terminated if there is no null byte
+ * in the first `dst_size` bytes of the array pointed to by `src`
+ * This function is a wrapper over strncpy which adds null byte as the last byte
+ * @param dst Pointer to the destination char array
+ * @param src Pointer to the source char array
+ * @param dst_size size of the destination char array
+ */
+char *he_safe_strncpy(char *dst, const char *src, size_t dst_size);
+
 #endif  // HE_H


### PR DESCRIPTION
## Description
In order for a function to be available publicly, it has to be added to the file `he.h` too. The he.h file is auto-generated by running the command `earthly +public-header`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI Tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`