### PR TITLE
CVPN-245 Support hybrid kyber level 5 in UDP

### DIFF
--- a/include/he.h
+++ b/include/he.h
@@ -194,6 +194,8 @@ typedef enum he_return_code {
   HE_ERR_BAD_FRAGMENT = -60,
   /// Error occurred during secure renegotiation
   HE_ERR_SECURE_RENEGOTIATION_ERROR = -61,
+  /// Unable to use ClientHello Fragment in D/TLS
+  HE_ERR_CANNOT_ENABLE_CH_FRAG = -62,
 } he_return_code_t;
 
 /**

--- a/public/he.h
+++ b/public/he.h
@@ -194,6 +194,8 @@ typedef enum he_return_code {
   HE_ERR_BAD_FRAGMENT = -60,
   /// Error occurred during secure renegotiation
   HE_ERR_SECURE_RENEGOTIATION_ERROR = -61,
+  /// Unable to use ClientHello Fragment in D/TLS
+  HE_ERR_CANNOT_ENABLE_CH_FRAG = -62,
 } he_return_code_t;
 
 /**

--- a/src/he/conn.c
+++ b/src/he/conn.c
@@ -236,6 +236,13 @@ static he_return_code_t he_conn_internal_connect(he_conn_t *conn, he_ssl_ctx_t *
       // MTU size is invalid
       return HE_ERR_INVALID_MTU_SIZE;
     }
+
+    if(conn->is_server) {
+      res = wolfSSL_dtls13_allow_ch_frag(conn->wolf_ssl, 1);
+      if(res != SSL_SUCCESS) {
+        return HE_ERR_CANNOT_ENABLE_CH_FRAG;
+      }
+    }
   } else {
     if(!conn->is_server) {
       // For client, enable SNI in the wolfssl object if the hostname is non-empty
@@ -272,13 +279,7 @@ static he_return_code_t he_conn_internal_connect(he_conn_t *conn, he_ssl_ctx_t *
 #ifndef HE_NO_PQC
   // Use PQC Keyshare
   if(!conn->is_server && conn->use_pqc) {
-    // We use KYBER_LEVEL1 for UDP because WolfSSL doesn't support fragmentation
-    // of the ClientHello yet.
-    if(ctx->connection_type == HE_CONNECTION_TYPE_DATAGRAM) {
-      res = wolfSSL_UseKeyShare(conn->wolf_ssl, WOLFSSL_P256_KYBER_LEVEL1);
-    } else {
-      res = wolfSSL_UseKeyShare(conn->wolf_ssl, WOLFSSL_P521_KYBER_LEVEL5);
-    }
+    res = wolfSSL_UseKeyShare(conn->wolf_ssl, WOLFSSL_P521_KYBER_LEVEL5);
     if(res != SSL_SUCCESS) {
       return HE_ERR_INIT_FAILED;
     }

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -288,6 +288,22 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
     return HE_ERR_INIT_FAILED;
   }
 
+#ifndef HE_NO_PQC
+  int SERVER_CURVE_PQC_GROUPS[4] = {WOLFSSL_P521_KYBER_LEVEL5, WOLFSSL_P256_KYBER_LEVEL1,
+                                    WOLFSSL_ECC_SECP256R1, WOLFSSL_ECC_X25519};
+
+  res = wolfSSL_CTX_set_groups(ctx->wolf_ctx, SERVER_CURVE_PQC_GROUPS, 4);
+#else
+  int SERVER_CURVE_BASE_GROUPS[2] = {WOLFSSL_ECC_SECP256R1, WOLFSSL_ECC_X25519};
+
+  res = wolfSSL_CTX_set_groups(ctx->wolf_ctx, SERVER_CURVE_BASE_GROUPS, 2);
+#endif
+
+  // Fail if the we cannot set curve groups
+  if(res != SSL_SUCCESS) {
+    return HE_ERR_INIT_FAILED;
+  }
+
   return he_ssl_ctx_start_common(ctx);
 }
 

--- a/test/he/test_conn_connect.c
+++ b/test/he/test_conn_connect.c
@@ -210,7 +210,7 @@ void test_he_client_connect_pqc_keyshare_udp(void) {
 
   // Wolf set up
   setup_dtls_expectations();
-  wolfSSL_UseKeyShare_ExpectAndReturn(test_wolf_ssl, WOLFSSL_P256_KYBER_LEVEL1, SSL_SUCCESS);
+  wolfSSL_UseKeyShare_ExpectAndReturn(test_wolf_ssl, WOLFSSL_P521_KYBER_LEVEL5, SSL_SUCCESS);
 
   wolfSSL_negotiate_ExpectAndReturn(test_wolf_ssl, SSL_SUCCESS);
   // For this test it doesn't matter what it's called with as long as it's called

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -448,6 +448,13 @@ void test_he_server_connect_succeeds(void) {
       ":TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384",
       SSL_SUCCESS);
 
+#ifndef HE_NO_PQC
+  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 4, SSL_SUCCESS);
+#else
+  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 2, SSL_SUCCESS);
+#endif
+  wolfSSL_CTX_set_groups_IgnoreArg_groups();
+
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_dtls_read);
   wolfSSL_CTX_SetIOSend_Expect(my_ctx, he_wolf_dtls_write);
@@ -477,6 +484,13 @@ void test_he_server_connect_succeeds_streaming(void) {
 
   wolfSSL_CTX_set_cipher_list_ExpectAndReturn(
       my_ctx, "TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256", SSL_SUCCESS);
+
+#ifndef HE_NO_PQC
+  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 4, SSL_SUCCESS);
+#else
+  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 2, SSL_SUCCESS);
+#endif
+  wolfSSL_CTX_set_groups_IgnoreArg_groups();
 
   // Set mock callbacks from our own wolf code
   wolfSSL_CTX_SetIORecv_Expect(my_ctx, he_wolf_tls_read);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow lightway servers to accept higher security level when using hybrid Kyber KEM in UDP mode.

Used a feature in WolfSSL to allow a server to process a fragmented second/verified (one containing a valid cookie response) ClientHello message

Set which curve groups is accepted by the servers and their preference. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow both UDP and TCP connections to be protected with post-quantum crytopgrahy at the highest available level
Allow UDP connection to use hybrid ML-KEM 1024 in the future

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI + unit test

Tested with a  `xv-helium-server`  with new lightway-core with `xv-helium-cli` that has OLD (the first connection) and NEW (the second connection) lightway-core:
![image](https://github.com/user-attachments/assets/53b374c0-3ff7-474e-878f-a365556a42cb)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`