### PR TITLE
Add missing module in windows build

### DIFF
--- a/windows/wolfssl.vcxproj
+++ b/windows/wolfssl.vcxproj
@@ -468,6 +468,7 @@
     <ClCompile Include="wolfcrypt\src\wc_port.c" />
     <ClCompile Include="wolfcrypt\src\wolfmath.c" />
     <ClCompile Include="wolfcrypt\src\wolfevent.c" />
+    <ClCompile Include="wolfcrypt\src\port\liboqs\liboqs.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix linking issues when we are building windows client applications. There were four unresolved functions, which was found in `wolfcrypt\src\port\liboqs\liboqs.c`

It was missing after we have bumped WolfSSL to 5.7.4

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`