### PR TITLE
CVPN-1636 Supports both ML-KEM and Kyber in server

### DIFF
--- a/3rd_party_deps.yml
+++ b/3rd_party_deps.yml
@@ -23,4 +23,4 @@
       --enable-tls13
       --enable-experimental
       --enable-sha3
-      --enable-kyber=all,original
+      --enable-kyber=all,original,ml-kem

--- a/ios/autotools-ios-helper.sh
+++ b/ios/autotools-ios-helper.sh
@@ -66,7 +66,7 @@ build() {
         --enable-aes-bitsliced \
         --enable-experimental \
         --enable-sha3 \
-        --enable-kyber=all,original
+        --enable-kyber=all,original,ml-kem
     make clean
     mkdir -p "${EXEC_PREFIX}"
     make V=1 -j"${MAKE_JOBS}" --debug=j

--- a/src/he/ssl_ctx.c
+++ b/src/he/ssl_ctx.c
@@ -289,10 +289,11 @@ he_return_code_t he_ssl_ctx_start_server(he_ssl_ctx_t *ctx) {
   }
 
 #ifndef HE_NO_PQC
-  int SERVER_CURVE_PQC_GROUPS[4] = {WOLFSSL_P521_KYBER_LEVEL5, WOLFSSL_P256_KYBER_LEVEL1,
-                                    WOLFSSL_ECC_SECP256R1, WOLFSSL_ECC_X25519};
+  int SERVER_CURVE_PQC_GROUPS[5] = {WOLFSSL_P521_ML_KEM_1024, WOLFSSL_P521_KYBER_LEVEL5,
+                                    WOLFSSL_P256_KYBER_LEVEL1, WOLFSSL_ECC_SECP256R1,
+                                    WOLFSSL_ECC_X25519};
 
-  res = wolfSSL_CTX_set_groups(ctx->wolf_ctx, SERVER_CURVE_PQC_GROUPS, 4);
+  res = wolfSSL_CTX_set_groups(ctx->wolf_ctx, SERVER_CURVE_PQC_GROUPS, 5);
 #else
   int SERVER_CURVE_BASE_GROUPS[2] = {WOLFSSL_ECC_SECP256R1, WOLFSSL_ECC_X25519};
 

--- a/test/he/test_ssl_ctx.c
+++ b/test/he/test_ssl_ctx.c
@@ -449,7 +449,7 @@ void test_he_server_connect_succeeds(void) {
       SSL_SUCCESS);
 
 #ifndef HE_NO_PQC
-  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 4, SSL_SUCCESS);
+  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 5, SSL_SUCCESS);
 #else
   wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 2, SSL_SUCCESS);
 #endif
@@ -486,7 +486,7 @@ void test_he_server_connect_succeeds_streaming(void) {
       my_ctx, "TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256", SSL_SUCCESS);
 
 #ifndef HE_NO_PQC
-  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 4, SSL_SUCCESS);
+  wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 5, SSL_SUCCESS);
 #else
   wolfSSL_CTX_set_groups_ExpectAndReturn(my_ctx, NULL, 2, SSL_SUCCESS);
 #endif

--- a/windows/wolfssl-user_settings-32.h
+++ b/windows/wolfssl-user_settings-32.h
@@ -209,7 +209,7 @@
 #define WOLFSSL_KYBER_ORIGINAL
 
 #undef WOLFSSL_NO_ML_KEM
-#define WOLFSSL_NO_ML_KEM
+// #define WOLFSSL_NO_ML_KEM
 
 // Needed for using WolfSSL's Kyber implementation
 #undef WOLFSSL_SHA3

--- a/windows/wolfssl-user_settings-64.h
+++ b/windows/wolfssl-user_settings-64.h
@@ -209,7 +209,7 @@
 #define WOLFSSL_KYBER_ORIGINAL
 
 #undef WOLFSSL_NO_ML_KEM
-#define WOLFSSL_NO_ML_KEM
+// #define WOLFSSL_NO_ML_KEM
 
 // Needed for using WolfSSL's Kyber implementation
 #undef WOLFSSL_SHA3

--- a/windows/wolfssl-user_settings-arm-64.h
+++ b/windows/wolfssl-user_settings-arm-64.h
@@ -209,7 +209,7 @@
 #define WOLFSSL_KYBER_ORIGINAL
 
 #undef WOLFSSL_NO_ML_KEM
-#define WOLFSSL_NO_ML_KEM
+// #define WOLFSSL_NO_ML_KEM
 
 // Needed for using WolfSSL's Kyber implementation
 #undef WOLFSSL_SHA3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add ML-KEM groups when we are compiling WolfSSL.

Server supports ML-KEM and Kyber simultaneously. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use officially approved standard ML-KEM from NIST to strengthen security


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a new helium server running locally and it can connect with:
1. Lightway C client with liboqs
2. Lighway C client w/o liboqs
3. New lightway rust without liboqs

Will add integration tests in helium-server once the client also migrates to ML-KEM
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`