### PR TITLE
CVPN-1681 Fix failed Kyber/ML-KEM handshake with non-AVX2 CPU

### DIFF
--- a/windows_32.yml
+++ b/windows_32.yml
@@ -18,6 +18,7 @@
         - git apply ../../wolfssl/0004-fix-kyber-mlkem-benchmark.patch
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
+        - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - "cp ../../windows/wolfssl-user_settings-32.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-32.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -18,6 +18,7 @@
         - git apply ../../wolfssl/0004-fix-kyber-mlkem-benchmark.patch
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
+        - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - "cp ../../windows/wolfssl-user_settings-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-64.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/windows_arm64.yml
+++ b/windows_arm64.yml
@@ -18,6 +18,7 @@
         - git apply ../../wolfssl/0004-fix-kyber-mlkem-benchmark.patch
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
+        - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - "cp ../../windows/wolfssl-user_settings-arm-64.h wolfssl/user_settings.h"
         - "cp -f ../../windows/wolfssl-user_settings-arm-64.h IDE/WIN/user_settings.h"
         - "cp -f ../../windows/wolfssl.vcxproj ./wolfssl.vcxproj"

--- a/wolfssl/0007-fix-kyber-prf-non-avx2.patch
+++ b/wolfssl/0007-fix-kyber-prf-non-avx2.patch
@@ -1,0 +1,51 @@
+From e507c466d5b97f1b1b063783f4ae020c38ebae4b Mon Sep 17 00:00:00 2001
+From: Sean Parkinson <sean@wolfssl.com>
+Date: Fri, 20 Dec 2024 11:03:58 +1000
+Subject: [PATCH] ML-KEM/Kyber: fix kyber_prf() for when no AVX2
+
+When no AVX2 available, kyber_prf() is called to produce more than one
+SHAKE-256 blocks worth of ouput. Otherwise only one block is needed.
+Changed function to support an outlen of greater than one block.
+---
+ wolfcrypt/src/wc_kyber_poly.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/wolfcrypt/src/wc_kyber_poly.c b/wolfcrypt/src/wc_kyber_poly.c
+index d947d37e95..76b5cd5d77 100644
+--- a/wolfcrypt/src/wc_kyber_poly.c
++++ b/wolfcrypt/src/wc_kyber_poly.c
+@@ -2074,17 +2074,24 @@ static int kyber_prf(wc_Shake* shake256, byte* out, unsigned int outLen,
+         (25 - KYBER_SYM_SZ / 8 - 1) * sizeof(word64));
+     state[WC_SHA3_256_COUNT - 1] = W64LIT(0x8000000000000000);
+ 
+-    if (IS_INTEL_BMI2(cpuid_flags)) {
+-        sha3_block_bmi2(state);
+-    }
+-    else if (IS_INTEL_AVX2(cpuid_flags) && (SAVE_VECTOR_REGISTERS2() == 0)) {
+-        sha3_block_avx2(state);
+-        RESTORE_VECTOR_REGISTERS();
+-    }
+-    else {
+-        BlockSha3(state);
++    while (outLen > 0) {
++        unsigned int len = min(outLen, WC_SHA3_256_BLOCK_SIZE);
++
++        if (IS_INTEL_BMI2(cpuid_flags)) {
++            sha3_block_bmi2(state);
++        }
++        else if (IS_INTEL_AVX2(cpuid_flags) &&
++                 (SAVE_VECTOR_REGISTERS2() == 0)) {
++            sha3_block_avx2(state);
++            RESTORE_VECTOR_REGISTERS();
++        }
++        else {
++            BlockSha3(state);
++        }
++        XMEMCPY(out, state, len);
++        out += len;
++        outLen -= len;
+     }
+-    XMEMCPY(out, state, outLen);
+ 
+     return 0;
+ #else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The patch is from:
https://github.com/wolfSSL/wolfssl/pull/8306

This patch fixes an issue where older CPUs, with no AVX2 support, fail to handshake Kyber/ML-KEM.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested a new server with this fix built in. Old and new clients can indeed connect to it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`