### PR TITLE
Force Ruby gem to install v0.31.1 ceedling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Build dependencies
         run: ceedling project:linux verbosity[4] clobber dependencies:make
       - name: Run wolfSSL Tests
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install gcc multi lib
         run: |
           sudo apt update
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install ARM Tools
         run: |
           sudo apt update
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install ARM Tools
         run: |
           sudo apt update
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install ARM Tools
         run: |
           sudo apt update
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install RISC-V Toolchain
         run: |
           sudo apt update
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Build dependencies
@@ -153,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Build dependencies
@@ -174,7 +174,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: gem install ceedling --no-user-install
+        run: gem install ceedling -v 0.31.1 --no-user-install
       - name: Check Ceedling version
         run: ceedling version
       - name: Set up Visual Studio shell
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Run build
@@ -212,7 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Run build
@@ -226,7 +226,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ceedling
-        run: sudo gem install ceedling --no-user-install
+        run: sudo gem install ceedling -v 0.31.1 --no-user-install
       - name: Run build
         run: |
           source android/android_env.sh ${{ matrix.arch }}

--- a/Earthfile
+++ b/Earthfile
@@ -8,7 +8,7 @@ debian-deps:
     RUN apt-get -y install --no-install-recommends build-essential git automake m4 libtool-bin cmake ruby-full python3-pip
     # Not including colrm seems to give an error when configuring wolfssl
     RUN apt-get -y install --no-install-recommends bsdmainutils
-    RUN gem install ceedling --no-user-install
+    RUN gem install ceedling -v 0.31.1 --no-user-install
     RUN apt-get -y install --no-install-recommends gcovr
 
 libhelium-deps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ceedling has officially released v1.0.0, which contains quite a bit of breaking changes. This commits updates CI and Earthfile to specify which version of ceedling to install to ensure the CI doesn't fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix failing CI and Earthile

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`