### PR TITLE
CVPN-1725 Fix illegal instruction error on older CPUs

### DIFF
--- a/windows_32.yml
+++ b/windows_32.yml
@@ -19,6 +19,8 @@
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
+        - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
+        - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-32.h >> wolfssl/user_settings.h"
         - "cp -f wolfssl/user_settings.h IDE/WIN/user_settings.h"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -19,6 +19,8 @@
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
+        - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
+        - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-64.h >> wolfssl/user_settings.h"
         - "cp -f wolfssl/user_settings.h IDE/WIN/user_settings.h"

--- a/windows_64_multithread.yml
+++ b/windows_64_multithread.yml
@@ -19,6 +19,8 @@
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
+        - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
+        - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-64.h >> wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-multithread.h >> wolfssl/user_settings.h"

--- a/windows_arm64.yml
+++ b/windows_arm64.yml
@@ -19,6 +19,8 @@
         - git apply ../../wolfssl/0005-fix-mlkem-get-curve-name.patch
         - git apply ../../wolfssl/0006-fix-kyber-get-curve-name.patch
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
+        - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
+        - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-arm-64.h >> wolfssl/user_settings.h"
         - "cp -f wolfssl/user_settings.h IDE/WIN/user_settings.h"

--- a/wolfssl/0008-intel-illegal-instruction.patch
+++ b/wolfssl/0008-intel-illegal-instruction.patch
@@ -1,0 +1,220 @@
+From e90e3aa7c69169a7c398edd274be3c0234444b6d Mon Sep 17 00:00:00 2001
+From: Sean Parkinson <sean@wolfssl.com>
+Date: Thu, 20 Feb 2025 22:28:40 +1000
+Subject: [PATCH] Intel AVX1/SSE2 ASM: no ymm/zmm regs no vzeroupper
+
+vzeroupper instruction not needed to be invoked unless ymm or zmm
+registers are used.
+---
+ wolfcrypt/src/aes_gcm_asm.S   |  2 --
+ wolfcrypt/src/aes_gcm_asm.asm |  2 --
+ wolfcrypt/src/chacha_asm.S    |  1 -
+ wolfcrypt/src/chacha_asm.asm  |  1 -
+ wolfcrypt/src/sha256_asm.S    |  8 --------
+ wolfcrypt/src/sha512_asm.S    | 12 ++++--------
+ 6 files changed, 4 insertions(+), 22 deletions(-)
+
+diff --git a/wolfcrypt/src/aes_gcm_asm.S b/wolfcrypt/src/aes_gcm_asm.S
+index b14620be0f..95ac60ae20 100644
+--- a/wolfcrypt/src/aes_gcm_asm.S
++++ b/wolfcrypt/src/aes_gcm_asm.S
+@@ -9910,7 +9910,6 @@ L_AES_GCM_init_avx1_iv_done:
+         vpaddd	L_avx1_aes_gcm_one(%rip), %xmm4, %xmm4
+         vmovdqa	%xmm5, (%r8)
+         vmovdqa	%xmm4, (%r9)
+-        vzeroupper
+         addq	$16, %rsp
+         popq	%r13
+         popq	%r12
+@@ -9985,7 +9984,6 @@ L_AES_GCM_aad_update_avx1_16_loop:
+         cmpl	%esi, %ecx
+         jl	L_AES_GCM_aad_update_avx1_16_loop
+         vmovdqa	%xmm5, (%rdx)
+-        vzeroupper
+         repz retq
+ #ifndef __APPLE__
+ .size	AES_GCM_aad_update_avx1,.-AES_GCM_aad_update_avx1
+diff --git a/wolfcrypt/src/aes_gcm_asm.asm b/wolfcrypt/src/aes_gcm_asm.asm
+index 2e4683cdd5..a818e86583 100644
+--- a/wolfcrypt/src/aes_gcm_asm.asm
++++ b/wolfcrypt/src/aes_gcm_asm.asm
+@@ -9832,7 +9832,6 @@ L_AES_GCM_init_avx1_iv_done:
+         vpaddd	xmm4, xmm4, OWORD PTR L_avx1_aes_gcm_one
+         vmovdqa	OWORD PTR [rax], xmm5
+         vmovdqa	OWORD PTR [r8], xmm4
+-        vzeroupper
+         vmovdqu	xmm6, OWORD PTR [rsp+16]
+         vmovdqu	xmm7, OWORD PTR [rsp+32]
+         vmovdqu	xmm8, OWORD PTR [rsp+48]
+@@ -9905,7 +9904,6 @@ L_AES_GCM_aad_update_avx1_16_loop:
+         cmp	ecx, edx
+         jl	L_AES_GCM_aad_update_avx1_16_loop
+         vmovdqa	OWORD PTR [r8], xmm5
+-        vzeroupper
+         vmovdqu	xmm6, OWORD PTR [rsp]
+         vmovdqu	xmm7, OWORD PTR [rsp+16]
+         add	rsp, 32
+diff --git a/wolfcrypt/src/chacha_asm.S b/wolfcrypt/src/chacha_asm.S
+index 6616e5b3d0..37e2a59306 100644
+--- a/wolfcrypt/src/chacha_asm.S
++++ b/wolfcrypt/src/chacha_asm.S
+@@ -1033,7 +1033,6 @@ L_chacha20_avx1_partial_end64:
+         subl	%r11d, %r8d
+         movl	%r8d, 76(%rdi)
+ L_chacha20_avx1_partial_done:
+-        vzeroupper
+         addq	$0x190, %rsp
+         popq	%r15
+         popq	%r14
+diff --git a/wolfcrypt/src/chacha_asm.asm b/wolfcrypt/src/chacha_asm.asm
+index 334b0555f6..e9988945b1 100644
+--- a/wolfcrypt/src/chacha_asm.asm
++++ b/wolfcrypt/src/chacha_asm.asm
+@@ -990,7 +990,6 @@ L_chacha20_avx1_partial_end64:
+         sub	r10d, r13d
+         mov	DWORD PTR [rcx+76], r10d
+ L_chacha20_avx1_partial_done:
+-        vzeroupper
+         vmovdqu	xmm6, OWORD PTR [rsp+400]
+         vmovdqu	xmm7, OWORD PTR [rsp+416]
+         vmovdqu	xmm8, OWORD PTR [rsp+432]
+diff --git a/wolfcrypt/src/sha256_asm.S b/wolfcrypt/src/sha256_asm.S
+index e180a5fc37..5d2d600490 100644
+--- a/wolfcrypt/src/sha256_asm.S
++++ b/wolfcrypt/src/sha256_asm.S
+@@ -273,7 +273,6 @@ _Transform_Sha256_SSE2_Sha:
+         movhpd	%xmm1, 16(%rdi)
+         movhpd	%xmm2, 24(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         repz retq
+ #ifndef __APPLE__
+ .size	Transform_Sha256_SSE2_Sha,.-Transform_Sha256_SSE2_Sha
+@@ -476,7 +475,6 @@ L_sha256_sha_len_sse2_start:
+         movhpd	%xmm1, 16(%rdi)
+         movhpd	%xmm2, 24(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         repz retq
+ #ifndef __APPLE__
+ .size	Transform_Sha256_SSE2_Sha_Len,.-Transform_Sha256_SSE2_Sha_Len
+@@ -2920,7 +2918,6 @@ _Transform_Sha256_AVX1:
+         addl	%r14d, 24(%rdi)
+         addl	%r15d, 28(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x40, %rsp
+         popq	%rbp
+         popq	%r15
+@@ -5327,7 +5324,6 @@ L_sha256_len_avx1_start:
+         movl	%r15d, 28(%rdi)
+         jnz	L_sha256_len_avx1_start
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x44, %rsp
+         popq	%rbp
+         popq	%r15
+@@ -7735,7 +7731,6 @@ _Transform_Sha256_AVX1_RORX:
+         addl	%r14d, 24(%rdi)
+         addl	%r15d, 28(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x40, %rsp
+         popq	%rbp
+         popq	%r15
+@@ -10101,7 +10096,6 @@ L_sha256_len_avx1_len_rorx_start:
+         movl	%r15d, 28(%rdi)
+         jnz	L_sha256_len_avx1_len_rorx_start
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x44, %rsp
+         popq	%rbp
+         popq	%r15
+@@ -10312,7 +10306,6 @@ _Transform_Sha256_AVX1_Sha:
+         vmovhpd	%xmm1, 16(%rdi)
+         vmovhpd	%xmm2, 24(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         repz retq
+ #ifndef __APPLE__
+ .size	Transform_Sha256_AVX1_Sha,.-Transform_Sha256_AVX1_Sha
+@@ -10487,7 +10480,6 @@ L_sha256_sha_len_avx1_start:
+         vmovhpd	%xmm1, 16(%rdi)
+         vmovhpd	%xmm2, 24(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         repz retq
+ #ifndef __APPLE__
+ .size	Transform_Sha256_AVX1_Sha_Len,.-Transform_Sha256_AVX1_Sha_Len
+diff --git a/wolfcrypt/src/sha512_asm.S b/wolfcrypt/src/sha512_asm.S
+index 84cb7c8269..fe7278541d 100644
+--- a/wolfcrypt/src/sha512_asm.S
++++ b/wolfcrypt/src/sha512_asm.S
+@@ -159,7 +159,7 @@ _Transform_Sha512_AVX1:
+         movq	%r12, %rax
+         xorq	%r10, %rbx
+         # Start of 16 rounds
+-L_sha256_len_avx1_start:
++L_transform_sha512_avx1_start:
+         vpaddq	(%rsi), %xmm0, %xmm8
+         vpaddq	16(%rsi), %xmm1, %xmm9
+         vmovdqu	%xmm8, (%rsp)
+@@ -906,7 +906,7 @@ L_sha256_len_avx1_start:
+         vpaddq	%xmm7, %xmm8, %xmm7
+         # msg_sched done: 14-17
+         subl	$0x01, 128(%rsp)
+-        jne	L_sha256_len_avx1_start
++        jne	L_transform_sha512_avx1_start
+         vpaddq	(%rsi), %xmm0, %xmm8
+         vpaddq	16(%rsi), %xmm1, %xmm9
+         vmovdqu	%xmm8, (%rsp)
+@@ -1372,7 +1372,6 @@ L_sha256_len_avx1_start:
+         addq	%r14, 48(%rdi)
+         addq	%r15, 56(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x88, %rsp
+         popq	%r15
+         popq	%r14
+@@ -2664,7 +2663,6 @@ L_sha512_len_avx1_start:
+         movq	%r15, 56(%rdi)
+         jnz	L_sha512_len_avx1_begin
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x90, %rsp
+         popq	%rbp
+         popq	%r15
+@@ -2805,7 +2803,7 @@ _Transform_Sha512_AVX1_RORX:
+         vmovdqu	%xmm8, 96(%rsp)
+         vmovdqu	%xmm9, 112(%rsp)
+         # Start of 16 rounds
+-L_sha256_len_avx1_rorx_start:
++L_transform_sha512_avx1_rorx_start:
+         addq	$0x80, %rsi
+         # msg_sched: 0-1
+         # rnd_0: 0 - 0
+@@ -3512,7 +3510,7 @@ L_sha256_len_avx1_rorx_start:
+         vmovdqu	%xmm8, 96(%rsp)
+         vmovdqu	%xmm9, 112(%rsp)
+         subl	$0x01, 128(%rsp)
+-        jne	L_sha256_len_avx1_rorx_start
++        jne	L_transform_sha512_avx1_rorx_start
+         # rnd_all_2: 0-1
+         # rnd_0: 0 - 7
+         rorxq	$14, %r12, %rax
+@@ -3931,7 +3929,6 @@ L_sha256_len_avx1_rorx_start:
+         addq	%r14, 48(%rdi)
+         addq	%r15, 56(%rdi)
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x88, %rsp
+         popq	%r15
+         popq	%r14
+@@ -5168,7 +5165,6 @@ L_sha512_len_avx1_rorx_start:
+         movq	%r15, 56(%rdi)
+         jnz	L_sha512_len_avx1_rorx_begin
+         xorq	%rax, %rax
+-        vzeroupper
+         addq	$0x90, %rsp
+         popq	%rbp
+         popq	%r15

--- a/wolfssl/0009-reverse-only-with-avx12.patch
+++ b/wolfssl/0009-reverse-only-with-avx12.patch
@@ -1,0 +1,34 @@
+From b1048870420bef0294b495e4b88871aa4e3c78ee Mon Sep 17 00:00:00 2001
+From: Sean Parkinson <sean@wolfssl.com>
+Date: Thu, 27 Feb 2025 09:25:13 +1000
+Subject: [PATCH] SHA256: Intel flags has SHA but not AVX1 or AVX2
+
+Reversal of bytes when IS_INTEL_SHA only is same as when AVX1 or AVX2.
+---
+ wolfcrypt/src/sha256.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/wolfcrypt/src/sha256.c b/wolfcrypt/src/sha256.c
+index 93b6afc546..31a557c8d0 100644
+--- a/wolfcrypt/src/sha256.c
++++ b/wolfcrypt/src/sha256.c
+@@ -209,7 +209,8 @@ on the specific device platform.
+         #define SHA256_UPDATE_REV_BYTES(ctx) (sha256->sha_method == SHA256_C)
+     #else
+         #define SHA256_UPDATE_REV_BYTES(ctx) \
+-            (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
++            (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags) && \
++             !IS_INTEL_SHA(intel_flags))
+     #endif
+ #elif defined(FREESCALE_MMCAU_SHA)
+     #define SHA256_UPDATE_REV_BYTES(ctx)    0 /* reverse not needed on update */
+@@ -1652,7 +1653,8 @@ static int InitSha256(wc_Sha256* sha256)
+         #ifdef WC_C_DYNAMIC_FALLBACK
+         if (sha256->sha_method != SHA256_C)
+         #else
+-        if (IS_INTEL_AVX1(intel_flags) || IS_INTEL_AVX2(intel_flags))
++        if (IS_INTEL_AVX1(intel_flags) || IS_INTEL_AVX2(intel_flags) ||
++            IS_INTEL_SHA(intel_flags))
+         #endif
+         #endif
+         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix illegal instruction on older desktop CPUs. Applied the 2 PRs provided by WolfSSL to fix this issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent clients that are using older CPU from crashing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Tested it on the platform that was not working originally and verified the 2 fixes work, and can indeed connect to our VPN servers
- Passed integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`