### PR TITLE
CVPN-1945 Add patch MTU fix patch file and apply it

### DIFF
--- a/windows_32.yml
+++ b/windows_32.yml
@@ -21,6 +21,7 @@
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
         - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
+        - git apply ../../wolfssl/0010-CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-32.h >> wolfssl/user_settings.h"
         - "cp -f wolfssl/user_settings.h IDE/WIN/user_settings.h"

--- a/windows_64.yml
+++ b/windows_64.yml
@@ -21,6 +21,7 @@
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
         - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
+        - git apply ../../wolfssl/0010-CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-64.h >> wolfssl/user_settings.h"
         - "cp -f wolfssl/user_settings.h IDE/WIN/user_settings.h"

--- a/windows_64_multithread.yml
+++ b/windows_64_multithread.yml
@@ -21,6 +21,7 @@
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
         - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
+        - git apply ../../wolfssl/0010-CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-64.h >> wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-multithread.h >> wolfssl/user_settings.h"

--- a/windows_arm64.yml
+++ b/windows_arm64.yml
@@ -21,6 +21,7 @@
         - git apply ../../wolfssl/0007-fix-kyber-prf-non-avx2.patch
         - git apply ../../wolfssl/0008-intel-illegal-instruction.patch
         - git apply ../../wolfssl/0009-reverse-only-with-avx12.patch
+        - git apply ../../wolfssl/0010-CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch
         - "cp ../../windows/wolfssl-user_settings-common.h wolfssl/user_settings.h"
         - "cat ../../windows/wolfssl-user_settings-arm-64.h >> wolfssl/user_settings.h"
         - "cp -f wolfssl/user_settings.h IDE/WIN/user_settings.h"

--- a/wolfssl/0010-CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch
+++ b/wolfssl/0010-CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch
@@ -1,0 +1,28 @@
+From beb661e72616c991b597e17a147dbbb9450dc34e Mon Sep 17 00:00:00 2001
+From: Peter Membrey <pete.m@expressvpn.com>
+Date: Wed, 16 Apr 2025 12:09:39 +0800
+Subject: [PATCH] CVPN-1945 Lower max mtu for DTLS 1.3 handshake messages to
+ prevent fragmentation
+
+---
+ src/dtls13.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/dtls13.c b/src/dtls13.c
+index cc2c02fa4..6dc086103 100644
+--- a/src/dtls13.c
++++ b/src/dtls13.c
+@@ -971,7 +971,9 @@ static int Dtls13SendFragmentedInternal(WOLFSSL* ssl)
+     isEncrypted = Dtls13TypeIsEncrypted(
+         (enum HandShakeType)ssl->dtls13FragHandshakeType);
+     rlHeaderLength = Dtls13GetRlHeaderLength(ssl, isEncrypted);
+-    maxFragment = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
++    // Pete M: Removing 500 bytes to ensure the packet fragments at a ratio
++    //         of 70/30 rather than 99/1
++    maxFragment = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE) - 500;
+ 
+     remainingSize = ssl->dtls13MessageLength - ssl->dtls13FragOffset;
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
### CVPN-1945: Lower Max MTU for DTLS 1.3 Handshake Messages to Prevent Fragmentation

#### Context

During the DTLS 1.3 handshake, large post-quantum certificates are exchanged. While DTLS supports message fragmentation, the first packet in the exchange remains extremely close to the MTU limit—just 15 bytes of headroom in the worst-case scenario (e.g., PPPoE or PPPoA networks). This minimal buffer leads to fragmentation on many networks despite the use of handshake fragmentation.

We observed that the current fragmentation behavior splits packets in a ~95/5 ratio, resulting in a large first packet and a tiny second one. This causes the first packet to be fragmented anyway, defeating the purpose of the feature.

#### Change

This patch modifies the `Dtls13SendFragmentedInternal()` function in `dtls13.c` to reduce the maximum fragment size by 500 bytes:

```c
maxFragment = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE) - 500;
```

This shifts the packet split to roughly a 70/30 ratio, reducing the likelihood of fragmentation across common network types.

#### Notes

- This change is limited in scope and only affects the initial DTLS 1.3 handshake.
- It is not intended as a permanent fix but rather a practical workaround while a more robust solution is discussed with wolfSSL upstream.

#### Testing

Confirmed that handshake messages now split more evenly, and initial packets no longer exceed common MTU thresholds, preventing fragmentation during connection setup.