### PR TITLE
pmtud: update state before invoking cb function

### DIFF
--- a/src/he/pmtud.c
+++ b/src/he/pmtud.c
@@ -38,10 +38,10 @@ static void he_internal_pmtud_change_state(he_conn_t *conn, he_pmtud_state_t sta
   if(conn == NULL) {
     return;
   }
+  conn->pmtud.state = state;
   if(conn->pmtud_state_change_cb) {
     conn->pmtud_state_change_cb(conn, state, conn->data);
   }
-  conn->pmtud.state = state;
 }
 
 he_return_code_t he_internal_pmtud_send_probe(he_conn_t *conn, uint16_t probe_mtu) {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Currently the pmtud.state is updated after the cb function is invoked, which can cause state inconsistencies if the pmtud.state is referenced in the cb function.

Changing the order such that the pmtud.state is updated before the cb function is invoked.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [x] The correct base branch is being used, if not `main`