### PR TITLE
pmtud: base should fallback to MIN_PLPMTU when INITIAL_PLPMTU failed

### DIFF
--- a/src/he/pmtud.c
+++ b/src/he/pmtud.c
@@ -164,6 +164,7 @@ he_return_code_t he_internal_pmtud_handle_probe_timeout(he_conn_t *conn) {
     case HE_PMTUD_STATE_BASE:
       if(conn->pmtud.probing_size == INITIAL_PLPMTU) {
         // Try again using MIN_PLPMTU
+        conn->pmtud.base = MIN_PLPMTU;
         return he_internal_pmtud_send_probe(conn, MIN_PLPMTU);
       } else {
         // Unable to confirm the base PMTU, entering error state.

--- a/test/he/test_pmtud.c
+++ b/test/he/test_pmtud.c
@@ -273,6 +273,7 @@ void test_he_internal_pmtud_handle_probe_timeout_confirm_base_retry_with_min_plp
   conn.pmtud.state = HE_PMTUD_STATE_BASE;
   conn.pmtud.probe_count = MAX_PROBES;
   conn.pmtud_time_cb = pmtud_time_cb;
+  conn.pmtud.base = INITIAL_PLPMTU;
   conn.pmtud.probing_size = INITIAL_PLPMTU;
   conn.ping_next_id = 42;
 
@@ -289,8 +290,11 @@ void test_he_internal_pmtud_handle_probe_timeout_confirm_base_retry_with_min_plp
   TEST_ASSERT_EQUAL(1, conn.pmtud.probe_count);
   TEST_ASSERT_EQUAL(42, conn.pmtud.probe_pending_id);
 
-  // The new probe size should be MIN_PLPMTU
+  // The new probe size and base should be MIN_PLPMTU
   TEST_ASSERT_EQUAL(MIN_PLPMTU, conn.pmtud.probing_size);
+  // If MIN_PLPMTU probe succeeded, pmtud.base will be used as part of the next probe size
+  // calculation
+  TEST_ASSERT_EQUAL(MIN_PLPMTU, conn.pmtud.base);
 
   // pmtud_time_cb should be called to retry the error
   TEST_ASSERT_EQUAL(1, call_counter);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When INITIAL_PLPMTU probe failed, MIN_PLPMTU is tried but the base is not updated. Since the calculation of the next probe size is based on the base, it never drops below INITIAL_PLPMTU.

Setting base to MIN_PLPMTU would fix this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`