### PR TITLE
wolfssl: patch dn check for apple native cert validation

### DIFF
--- a/wolfssl/0012-fix-dn-check-apple-native-cert-validation.patch
+++ b/wolfssl/0012-fix-dn-check-apple-native-cert-validation.patch
@@ -1,0 +1,75 @@
+diff --git a/src/internal.c b/src/internal.c
+index eeba025f1..48f5174c2 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -222,7 +222,7 @@ int writeAeadAuthData(WOLFSSL* ssl, word16 sz, byte type, byte* additional,
+ #include <Security/SecTrust.h>
+ #include <Security/SecPolicy.h>
+ #if defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
+-static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
++static int DoAppleNativeCertValidation(WOLFSSL* ssl, const WOLFSSL_BUFFER_INFO* certs,
+                                             int totalCerts);
+ #endif /* #if defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION) */
+ #endif /* #if defined(__APPLE__) && defined(WOLFSSL_SYS_CA_CERTS) */
+@@ -16411,8 +16411,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
+             /* If we can't validate the peer cert chain against the CAs loaded
+              * into wolfSSL, try to validate against the system certificates
+              * using Apple's native trust APIs */
+-            if ((ret != 0) && (ssl->ctx->doAppleNativeCertValidationFlag)) {
+-                if (DoAppleNativeCertValidation(args->certs,
++            if ((ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E)) &&
++                (ssl->ctx->doAppleNativeCertValidationFlag)) {
++                if (DoAppleNativeCertValidation(ssl, args->certs,
+                                                      args->totalCerts)) {
+                     WOLFSSL_MSG("Apple native cert chain validation SUCCESS");
+                     ret = 0;
+@@ -41952,7 +41953,8 @@ cleanup:
+  * wolfSSL's built-in certificate validation mechanisms anymore. We instead
+  * must call into the Security Framework APIs to authenticate peer certificates
+  */
+-static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
++static int DoAppleNativeCertValidation(WOLFSSL* ssl,
++                                            const WOLFSSL_BUFFER_INFO* certs,
+                                             int totalCerts)
+ {
+     int i;
+@@ -41961,7 +41963,8 @@ static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
+     CFMutableArrayRef certArray = NULL;
+     SecCertificateRef secCert   = NULL;
+     SecTrustRef       trust     = NULL;
+-    SecPolicyRef      policy    = NULL ;
++    SecPolicyRef      policy    = NULL;
++    CFStringRef       hostname  = NULL;
+ 
+     WOLFSSL_ENTER("DoAppleNativeCertValidation");
+ 
+@@ -41990,7 +41993,18 @@ static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
+     }
+ 
+     /* Create trust object for SecCertifiate Ref */
+-    policy = SecPolicyCreateSSL(true, NULL);
++    if (ssl->buffers.domainName.buffer &&
++            ssl->buffers.domainName.length > 0) {
++        /* Create policy with specified value to require host name match */
++        hostname = CFStringCreateWithCString(kCFAllocatorDefault,
++                                (const char*)ssl->buffers.domainName.buffer,
++                                 kCFStringEncodingUTF8);
++    }
++    if (hostname != NULL) {
++        policy = SecPolicyCreateSSL(true, hostname);
++    } else {
++        policy = SecPolicyCreateSSL(true, NULL);
++    }
+     status = SecTrustCreateWithCertificates(certArray, policy, &trust);
+     if (status != errSecSuccess) {
+         WOLFSSL_MSG_EX("Error creating trust object, "
+@@ -42021,6 +42035,9 @@ cleanup:
+     if (policy) {
+         CFRelease(policy);
+     }
++    if (hostname) {
++        CFRelease(hostname);
++    }
+ 
+     WOLFSSL_LEAVE("DoAppleNativeCertValidation", ret);
+ 


### PR DESCRIPTION
## Description

Adopting a patch from https://github.com/wolfSSL/wolfssl/pull/8833 on top of the current wolfssl version we are using. This patch ensures the domain check request is properly executed when using the Apple Native Certificate Validation routine. 

This does not affect the security of Lightway since this routine isn't specifically called.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`