### PR TITLE
CVPN-2035: Fix using correct struct for validating length

### DIFF
--- a/src/he/msg_handlers.c
+++ b/src/he/msg_handlers.c
@@ -279,7 +279,7 @@ he_return_code_t he_handle_msg_auth(he_conn_t *conn, uint8_t *packet, int length
 
         // Check the auth token length
         uint16_t auth_token_length = ntohs(msg_token->token_length);
-        if(auth_token_length > (length - sizeof(he_msg_auth_hdr_t))) {
+        if(auth_token_length > (length - sizeof(he_msg_auth_token_t))) {
           return HE_ERR_PACKET_TOO_SMALL;
         }
         auth_state = conn->auth_token_cb(conn, msg_token->token, auth_token_length, conn->data);
@@ -298,7 +298,7 @@ he_return_code_t he_handle_msg_auth(he_conn_t *conn, uint8_t *packet, int length
 
         // Check the auth buffer length
         uint16_t auth_buf_length = ntohs(msg_buf->buffer_length);
-        if(auth_buf_length > (length - sizeof(he_msg_auth_hdr_t))) {
+        if(auth_buf_length > (length - sizeof(he_msg_auth_buf_t))) {
           return HE_ERR_PACKET_TOO_SMALL;
         }
         auth_state = conn->auth_buf_cb(conn, msg_buf->header.auth_type, msg_buf->buffer,

--- a/test/he/test_msg_handlers.c
+++ b/test/he/test_msg_handlers.c
@@ -837,6 +837,14 @@ void test_msg_auth_token_packet_too_small(void) {
   // Call with a small size to trigger the size check
   he_return_code_t res = he_handle_msg_auth(conn, empty_data, 4);
   TEST_ASSERT_EQUAL(HE_ERR_PACKET_TOO_SMALL, res);
+
+  auth_message->header.auth_type = HE_AUTH_TYPE_TOKEN;
+  // Fake buffer length
+  auth_message->token_length = ntohs(4);
+
+  // Call with a small size to trigger the size check
+  res = he_handle_msg_auth(conn, empty_data, sizeof(he_msg_auth_token_t) + 2);
+  TEST_ASSERT_EQUAL(HE_ERR_PACKET_TOO_SMALL, res);
 }
 
 void test_msg_auth_token_packet_invalid_length(void) {
@@ -905,6 +913,14 @@ void test_msg_auth_buf_packet_too_small(void) {
 
   // Call with a small size to trigger the size check
   he_return_code_t res = he_handle_msg_auth(conn, empty_data, 4);
+  TEST_ASSERT_EQUAL(HE_ERR_PACKET_TOO_SMALL, res);
+
+  auth_message->header.auth_type = HE_AUTH_TYPE_CB;
+  // Fake buffer length
+  auth_message->buffer_length = ntohs(4);
+
+  // Call with a small size to trigger the size check
+  res = he_handle_msg_auth(conn, empty_data, sizeof(he_msg_auth_buf_t) + 2);
   TEST_ASSERT_EQUAL(HE_ERR_PACKET_TOO_SMALL, res);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The memory bound check had used `he_msg_auth_hdr_t` instead of `he_msg_auth_buf_t` or `he_msg_auth_token_t` struct in the auth flow.
The difference between the structs `he_msg_auth_buf_t` and `he_msg_auth_hdr_t` is 2.

This causes memory bounding logic to fail, allowing malicious requests with additional 2 bytes in length to continue. (ex: actual buf: 2 bytes, buf_length: 4)
But since we use local stack buffer which is reseted on every packet, the bytes sent to the callback could only be having 0 values.
https://github.com/expressvpn/lightway-core/blob/d51702d8f8bd37874e5e70da434bf22930a6b48a/src/he/flow.c#L464

Fix this by using the correct struct in bound checking.
Tests which were added in first commit will pass now after adding fix.

## Motivation and Context

This bug is reported through BugCrowd

## How Has This Been Tested?

Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`